### PR TITLE
Add CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
 
 install:
  - pip install -U pip
- - pip install -U flake8 pytest pytest-cov
+ - pip install -U flake8 freezegun pytest pytest-cov
  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install -U black; fi
  - pip install -e .
 

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -65,6 +65,11 @@ def _filter(data, start_date=None, end_date=None):
 
 def _total(data):
     """Sum all downloads per category, regardless of date"""
+
+    # Only sum lists of dicts, not a single dict
+    if isinstance(data, dict):
+        return data
+
     totalled = {}
     for row in data:
         try:

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -15,7 +15,7 @@ BASE_URL = "https://pypistats.org/api/"
 
 
 def pypi_stats_api(
-    endpoint, params=None, output="table", start_date=None, end_date=None, total=False
+    endpoint, params=None, output="table", start_date=None, end_date=None, total=True
 ):
     """Call the API and return JSON"""
     if params:

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -89,7 +89,7 @@ def _tabulate(data):
         header_list = list(data.keys())
         writer.value_matrix = [data]
     elif isinstance(data, list):
-        header_list = list(set().union(*(d.keys() for d in data)))
+        header_list = sorted(set().union(*(d.keys() for d in data)))
         writer.value_matrix = data
 
     # Move downloads last

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -4,6 +4,9 @@
 CLI with subcommands for pypistats
 """
 import argparse
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
 
 import pypistats
 
@@ -65,6 +68,7 @@ def recent(args):
         argument("-m", "--mirrors", choices=("true", "false", "with", "without")),
         argument("-sd", "--start-date", help="yyyy-mm-dd"),
         argument("-ed", "--end-date", help="yyyy-mm-dd"),
+        argument("-l", "--last-month", action="store_true"),
     ]
 )
 def overall(args):
@@ -86,6 +90,7 @@ def overall(args):
         argument("-v", "--version", help="e.g. 2 or 3"),
         argument("-sd", "--start-date", help="yyyy-mm-dd"),
         argument("-ed", "--end-date", help="yyyy-mm-dd"),
+        argument("-l", "--last-month", action="store_true"),
     ]
 )
 def python_major(args):
@@ -105,6 +110,7 @@ def python_major(args):
         argument("-v", "--version", help="e.g. 2.7 or 3.6"),
         argument("-sd", "--start-date", help="yyyy-mm-dd"),
         argument("-ed", "--end-date", help="yyyy-mm-dd"),
+        argument("-l", "--last-month", action="store_true"),
     ]
 )
 def python_minor(args):
@@ -124,6 +130,7 @@ def python_minor(args):
         argument("-o", "--os", help="e.g. windows, linux, darwin or other"),
         argument("-sd", "--start-date", help="yyyy-mm-dd"),
         argument("-ed", "--end-date", help="yyyy-mm-dd"),
+        argument("-l", "--last-month", action="store_true"),
     ]
 )
 def system(args):
@@ -134,11 +141,23 @@ def system(args):
     )
 
 
+def _last_month():
+    """Helper to return start_date and end_date of the previous month as yyyy-mm-dd"""
+    today = date.today()
+    d = today - relativedelta(months=1)
+    first = date(d.year, d.month, 1)
+    last = date(today.year, today.month, 1) - relativedelta(days=1)
+    return str(first), str(last)
+
+
 def main():
     args = cli.parse_args()
     if args.subcommand is None:
         cli.print_help()
     else:
+        if args.last_month:
+            args.start_date, args.end_date = _last_month()
+
         args.func(args)
 
 

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -155,7 +155,7 @@ def main():
     if args.subcommand is None:
         cli.print_help()
     else:
-        if args.last_month:
+        if hasattr(args, "last_month") and args.last_month:
             args.start_date, args.end_date = _last_month()
 
         args.func(args)

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -63,32 +63,75 @@ def recent(args):
     [
         argument("package"),
         argument("-m", "--mirrors", choices=("true", "false", "with", "without")),
+        argument("-sd", "--start-date", help="yyyy-mm-dd"),
+        argument("-ed", "--end-date", help="yyyy-mm-dd"),
     ]
 )
 def overall(args):
     if args.mirrors in ["with", "without"]:
         args.mirrors = args.mirrors == "with"
-    print(pypistats.overall(args.package, mirrors=args.mirrors))
-
-
-@subcommand([argument("package"), argument("-v", "--version", help="e.g. 2 or 3")])
-def python_major(args):
-    print(pypistats.python_major(args.package, version=args.version))
-
-
-@subcommand([argument("package"), argument("-v", "--version", help="e.g. 2.7 or 3.6")])
-def python_minor(args):
-    print(pypistats.python_minor(args.package, version=args.version))
+    print(
+        pypistats.overall(
+            args.package,
+            mirrors=args.mirrors,
+            start_date=args.start_date,
+            end_date=args.end_date,
+        )
+    )
 
 
 @subcommand(
     [
         argument("package"),
-        argument("-o", "--os", help="e.g. windows, linux, darwin or othe"),
+        argument("-v", "--version", help="e.g. 2 or 3"),
+        argument("-sd", "--start-date", help="yyyy-mm-dd"),
+        argument("-ed", "--end-date", help="yyyy-mm-dd"),
+    ]
+)
+def python_major(args):
+    print(
+        pypistats.python_major(
+            args.package,
+            version=args.version,
+            start_date=args.start_date,
+            end_date=args.end_date,
+        )
+    )
+
+
+@subcommand(
+    [
+        argument("package"),
+        argument("-v", "--version", help="e.g. 2.7 or 3.6"),
+        argument("-sd", "--start-date", help="yyyy-mm-dd"),
+        argument("-ed", "--end-date", help="yyyy-mm-dd"),
+    ]
+)
+def python_minor(args):
+    print(
+        pypistats.python_minor(
+            args.package,
+            version=args.version,
+            start_date=args.start_date,
+            end_date=args.end_date,
+        )
+    )
+
+
+@subcommand(
+    [
+        argument("package"),
+        argument("-o", "--os", help="e.g. windows, linux, darwin or other"),
+        argument("-sd", "--start-date", help="yyyy-mm-dd"),
+        argument("-ed", "--end-date", help="yyyy-mm-dd"),
     ]
 )
 def system(args):
-    print(pypistats.system(args.package, os=args.os))
+    print(
+        pypistats.system(
+            args.package, os=args.os, start_date=args.start_date, end_date=args.end_date
+        )
+    )
 
 
 def main():

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+"""
+CLI with subcommands for pypistats
+"""
+import argparse
+
+import pypistats
+
+cli = argparse.ArgumentParser()
+subparsers = cli.add_subparsers(dest="subcommand")
+
+
+def argument(*name_or_flags, **kwargs):
+    """Convenience function to properly format arguments to pass to the
+    subcommand decorator.
+
+    """
+    return (list(name_or_flags), kwargs)
+
+
+def subcommand(args=None, parent=subparsers):
+    """Decorator to define a new subcommand in a sanity-preserving way.
+    The function will be stored in the ``func`` variable when the parser
+    parses arguments so that it can be called directly like so::
+
+        args = cli.parse_args()
+        args.func(args)
+
+    Usage example::
+
+        @subcommand([argument("-d", help="Enable debug mode", action="store_true")])
+        def subcommand(args):
+            print(args)
+
+    Then on the command line::
+
+        $ python cli.py subcommand -d
+
+    https://mike.depalatis.net/blog/simplifying-argparse.html
+    """
+    if args is None:
+        args = []
+
+    def decorator(func):
+        func2 = getattr(pypistats, func.__name__)
+        parser = parent.add_parser(func.__name__, description=func2.__doc__)
+        for arg in args:
+            parser.add_argument(*arg[0], **arg[1])
+        parser.set_defaults(func=func)
+
+    return decorator
+
+
+@subcommand(
+    [argument("package"), argument("-p", "--period", choices=("day", "week", "month"))]
+)
+def recent(args):
+    print(pypistats.recent(args.package, period=args.period))
+
+
+@subcommand(
+    [
+        argument("package"),
+        argument("-m", "--mirrors", choices=("true", "false", "with", "without")),
+    ]
+)
+def overall(args):
+    if args.mirrors in ["with", "without"]:
+        args.mirrors = args.mirrors == "with"
+    print(pypistats.overall(args.package, mirrors=args.mirrors))
+
+
+@subcommand([argument("package"), argument("-v", "--version", help="e.g. 2 or 3")])
+def python_major(args):
+    print(pypistats.python_major(args.package, version=args.version))
+
+
+@subcommand([argument("package"), argument("-v", "--version", help="e.g. 2.7 or 3.6")])
+def python_minor(args):
+    print(pypistats.python_minor(args.package, version=args.version))
+
+
+@subcommand(
+    [
+        argument("package"),
+        argument("-o", "--os", help="e.g. windows, linux, darwin or othe"),
+    ]
+)
+def system(args):
+    print(pypistats.system(args.package, os=args.os))
+
+
+def main():
+    args = cli.parse_args()
+    if args.subcommand is None:
+        cli.print_help()
+    else:
+        args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     keywords=["PyPI", "downloads", "statistics", "stats", "BigQuery"],
     packages=find_packages(),
     entry_points={"console_scripts": ["pypistats = pypistats.cli:main"]},
-    install_requires=["pytablewriter>=0.32.0", "requests"],
+    install_requires=["pytablewriter>=0.32.0", "python-dateutil", "requests"],
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     license="MIT",
     keywords=["PyPI", "downloads", "statistics", "stats", "BigQuery"],
     packages=find_packages(),
+    entry_points={"console_scripts": ["pypistats = pypistats.cli:main"]},
     install_requires=["pytablewriter>=0.32.0", "requests"],
     python_requires=">=3.6",
     classifiers=[

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+"""
+Unit tests for cli
+"""
+import unittest
+
+from freezegun import freeze_time
+
+from pypistats import cli
+
+
+class TestCli(unittest.TestCase):
+    @freeze_time("2018-09-25")
+    def test__last_month(self):
+        # Arrange
+        # Act
+        first, last = cli._last_month()
+
+        # Assert
+        self.assertEqual(first, "2018-08-01")
+        self.assertEqual(last, "2018-08-31")

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -159,3 +159,13 @@ class TestPypiStats(unittest.TestCase):
         self.assertEqual(len(output), 12)
         self.assertEqual(output[0]["category"], "2.4")
         self.assertEqual(output[0]["downloads"], 9)
+
+    def test__total_recent(self):
+        # Arrange
+        data = {"last_day": 123002, "last_month": 3254221, "last_week": 761649}
+
+        # Act
+        output = pypistats._total(data)
+
+        # Assert
+        self.assertEqual(output, data)

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -11,22 +11,22 @@ import pypistats
 class TestPypiStats(unittest.TestCase):
     def test__filter_no_filters_no_change(self):
         # Arrange
-        from data.python_minor import data as input
+        from data.python_minor import data
 
         # Act
-        output = pypistats._filter(input)
+        output = pypistats._filter(data)
 
         # Assert
-        self.assertEqual(input, output)
+        self.assertEqual(data, output)
 
     def test__filter_start_date(self):
         # Arrange
-        from data.python_minor import data as input
+        from data.python_minor import data
 
         start_date = "2018-09-22"
 
         # Act
-        output = pypistats._filter(input, start_date=start_date)
+        output = pypistats._filter(data, start_date=start_date)
 
         # Assert
         self.assertEqual(len(output), 20)
@@ -35,12 +35,12 @@ class TestPypiStats(unittest.TestCase):
 
     def test__filter_end_date(self):
         # Arrange
-        from data.python_minor import data as input
+        from data.python_minor import data
 
         end_date = "2018-04-22"
 
         # Act
-        output = pypistats._filter(input, end_date=end_date)
+        output = pypistats._filter(data, end_date=end_date)
 
         # Assert
         self.assertEqual(len(output), 62)
@@ -49,13 +49,13 @@ class TestPypiStats(unittest.TestCase):
 
     def test__filter_start_and_end_date(self):
         # Arrange
-        from data.python_minor import data as input
+        from data.python_minor import data
 
         start_date = "2018-09-01"
         end_date = "2018-09-11"
 
         # Act
-        output = pypistats._filter(input, start_date=start_date, end_date=end_date)
+        output = pypistats._filter(data, start_date=start_date, end_date=end_date)
 
         # Assert
         self.assertEqual(len(output), 112)
@@ -115,10 +115,10 @@ class TestPypiStats(unittest.TestCase):
 
     def test__total(self):
         # Arrange
-        from data.python_minor import data as input
+        from data.python_minor import data
 
         # Act
-        output = pypistats._total(input)
+        output = pypistats._total(data)
 
         # Assert
         self.assertEqual(len(output), 12)

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -113,6 +113,41 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(param, "&version=3.7")
 
+    def test__tabulate(self):
+        # Arrange
+        data = [
+            {"category": "2.6", "date": "2018-08-15", "downloads": 51},
+            {"category": "2.7", "date": "2018-08-15", "downloads": 63749},
+            {"category": "3.2", "date": "2018-08-15", "downloads": 2},
+            {"category": "3.3", "date": "2018-08-15", "downloads": 40},
+            {"category": "3.4", "date": "2018-08-15", "downloads": 6095},
+            {"category": "3.5", "date": "2018-08-15", "downloads": 20358},
+            {"category": "3.6", "date": "2018-08-15", "downloads": 35274},
+            {"category": "3.7", "date": "2018-08-15", "downloads": 6595},
+            {"category": "3.8", "date": "2018-08-15", "downloads": 3},
+            {"category": "null", "date": "2018-08-15", "downloads": 1019},
+        ]
+        expected_output = """
+| category |    date    | downloads |
+|----------|------------|----------:|
+|      2.6 | 2018-08-15 |        51 |
+|      2.7 | 2018-08-15 |     63749 |
+|      3.2 | 2018-08-15 |         2 |
+|      3.3 | 2018-08-15 |        40 |
+|      3.4 | 2018-08-15 |      6095 |
+|      3.5 | 2018-08-15 |     20358 |
+|      3.6 | 2018-08-15 |     35274 |
+|      3.7 | 2018-08-15 |      6595 |
+|      3.8 | 2018-08-15 |         3 |
+| null     | 2018-08-15 |      1019 |
+"""
+
+        # Act
+        output = pypistats._tabulate(data)
+
+        # Assert
+        self.assertEqual(output.strip(), expected_output.strip())
+
     def test__total(self):
         # Arrange
         from data.python_minor import data


### PR DESCRIPTION
Some examples:


```console
$ pypistats --help
usage: pypistats [-h] {recent,overall,python_major,python_minor,system} ...

positional arguments:
  {recent,overall,python_major,python_minor,system}

optional arguments:
  -h, --help            show this help message and exit
$ pypistats recent --help
usage: pypistats recent [-h] [-p {day,week,month}] package

Retrieve the aggregate download quantities for the last day/week/month

positional arguments:
  package

optional arguments:
  -h, --help            show this help message and exit
  -p {day,week,month}, --period {day,week,month}
$ pypistats recent pillow
| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|   123002 |    3254221 |    761649 |


$ pypistats recent pillow --period week
| last_week |
|----------:|
|    761649 |


$ pypistats python_minor --help
usage: pypistats python_minor [-h] [-v VERSION] [-sd START_DATE]
                              [-ed END_DATE] [-l]
                              package

Retrieve the aggregate daily download time series by Python minor version
number

positional arguments:
  package

optional arguments:
  -h, --help            show this help message and exit
  -v VERSION, --version VERSION
                        e.g. 2.7 or 3.6
  -sd START_DATE, --start-date START_DATE
                        yyyy-mm-dd
  -ed END_DATE, --end-date END_DATE
                        yyyy-mm-dd
  -l, --last-month
$ pypistats python_minor pillow -v 2.7
| category | downloads |
|---------:|----------:|
|      2.7 |   4434354 |


$ pypistats python_minor pillow --start-date 2018-08-01 --end-date 2018-08-02
| category | downloads |
|----------|----------:|
|      2.6 |       114 |
|      2.7 |    114607 |
|      3.2 |         3 |
|      3.3 |       184 |
|      3.4 |     10383 |
|      3.5 |     38745 |
|      3.6 |     86214 |
|      3.7 |     10809 |
|      3.8 |        10 |
| null     |      2124 |


$ pypistats python_minor pillow --last-month
| category | downloads |
|----------|----------:|
|      2.6 |      1968 |
|      2.7 |   1594594 |
|      3.1 |         3 |
|      3.2 |       244 |
|      3.3 |      1824 |
|      3.4 |    132468 |
|      3.5 |    467352 |
|      3.6 |   1035845 |
|      3.7 |    183275 |
|      3.8 |        88 |
| null     |     26253 |


$
```