### PR TITLE
Add --json option

### DIFF
--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -56,10 +56,18 @@ def subcommand(args=None, parent=subparsers):
 
 
 @subcommand(
-    [argument("package"), argument("-p", "--period", choices=("day", "week", "month"))]
+    [
+        argument("package"),
+        argument("-p", "--period", choices=("day", "week", "month")),
+        argument("-j", "--json", action="store_true", help="Output JSON"),
+    ]
 )
 def recent(args):
-    print(pypistats.recent(args.package, period=args.period))
+    print(
+        pypistats.recent(
+            args.package, period=args.period, output="json" if args.json else "table"
+        )
+    )
 
 
 @subcommand(
@@ -69,6 +77,7 @@ def recent(args):
         argument("-sd", "--start-date", help="yyyy-mm-dd"),
         argument("-ed", "--end-date", help="yyyy-mm-dd"),
         argument("-l", "--last-month", action="store_true"),
+        argument("-j", "--json", action="store_true", help="Output JSON"),
     ]
 )
 def overall(args):
@@ -80,6 +89,7 @@ def overall(args):
             mirrors=args.mirrors,
             start_date=args.start_date,
             end_date=args.end_date,
+            output="json" if args.json else "table",
         )
     )
 
@@ -91,6 +101,7 @@ def overall(args):
         argument("-sd", "--start-date", help="yyyy-mm-dd"),
         argument("-ed", "--end-date", help="yyyy-mm-dd"),
         argument("-l", "--last-month", action="store_true"),
+        argument("-j", "--json", action="store_true", help="Output JSON"),
     ]
 )
 def python_major(args):
@@ -100,6 +111,7 @@ def python_major(args):
             version=args.version,
             start_date=args.start_date,
             end_date=args.end_date,
+            output="json" if args.json else "table",
         )
     )
 
@@ -111,15 +123,18 @@ def python_major(args):
         argument("-sd", "--start-date", help="yyyy-mm-dd"),
         argument("-ed", "--end-date", help="yyyy-mm-dd"),
         argument("-l", "--last-month", action="store_true"),
+        argument("-j", "--json", action="store_true", help="Output JSON"),
     ]
 )
 def python_minor(args):
+
     print(
         pypistats.python_minor(
             args.package,
             version=args.version,
             start_date=args.start_date,
             end_date=args.end_date,
+            output="json" if args.json else "table",
         )
     )
 
@@ -131,12 +146,17 @@ def python_minor(args):
         argument("-sd", "--start-date", help="yyyy-mm-dd"),
         argument("-ed", "--end-date", help="yyyy-mm-dd"),
         argument("-l", "--last-month", action="store_true"),
+        argument("-j", "--json", action="store_true", help="Output JSON"),
     ]
 )
 def system(args):
     print(
         pypistats.system(
-            args.package, os=args.os, start_date=args.start_date, end_date=args.end_date
+            args.package,
+            os=args.os,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            output="json" if args.json else "table",
         )
     )
 


### PR DESCRIPTION
Fixes #7.

```console
$ pypistats python_minor --last-month pillow
| category | downloads |
|----------|----------:|
|      2.7 |   1594594 |
|      3.6 |   1035845 |
|      3.5 |    467352 |
|      3.7 |    183275 |
|      3.4 |    132468 |
| null     |     26253 |
|      2.6 |      1968 |
|      3.3 |      1824 |
|      3.2 |       244 |
|      3.8 |        88 |
|      3.1 |         3 |


$ pypistats python_minor --last-month pillow --json
{'data': [{'category': '2.6', 'downloads': 1968}, {'category': '2.7', 'downloads': 1594594}, {'category': '3.1', 'downloads': 3}, {'category': '3.2', 'downloads': 244}, {'category': '3.3', 'downloads': 1824}, {'category': '3.4', 'downloads': 132468}, {'category': '3.5', 'downloads': 467352}, {'category': '3.6', 'downloads': 1035845}, {'category': '3.7', 'downloads': 183275}, {'category': '3.8', 'downloads': 88}, {'category': 'null', 'downloads': 26253}], 'package': 'pillow', 'type': 'python_minor_downloads'}
```