### PR TITLE
Add percent column to tables

### DIFF
--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -155,6 +155,13 @@ def _tabulate(data):
     header_list.remove("downloads")
     writer.header_list = header_list
 
+    # Custom alignment
+    writer.align_list = [Align.AUTO] * len(header_list)
+    try:
+        writer.align_list[header_list.index("percent")] = Align.RIGHT
+    except ValueError:
+        pass
+
     return writer.dumps()
 
 

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -127,7 +127,7 @@ class TestPypiStats(unittest.TestCase):
 
     def test__tabulate(self):
         # Arrange
-        data = SAMPLE_DATA
+        data = copy.deepcopy(SAMPLE_DATA)
         expected_output = """
 | category |    date    | downloads |
 |----------|------------|----------:|
@@ -151,7 +151,7 @@ class TestPypiStats(unittest.TestCase):
 
     def test__sort(self):
         # Arrange
-        data = SAMPLE_DATA
+        data = copy.deepcopy(SAMPLE_DATA)
         expected_output = [
             {"category": "2.7", "date": "2018-08-15", "downloads": 63749},
             {"category": "3.6", "date": "2018-08-15", "downloads": 35274},

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -225,3 +225,34 @@ class TestPypiStats(unittest.TestCase):
 
         # Assert
         self.assertEqual(output, data)
+
+    def test__percent(self):
+        # Arrange
+        data = [
+            {"category": "2.7", "downloads": 63749},
+            {"category": "3.6", "downloads": 35274},
+            {"category": "2.6", "downloads": 51},
+            {"category": "3.2", "downloads": 2},
+        ]
+        expected_output = [
+            {"category": "2.7", "percent": "64.34%", "downloads": 63749},
+            {"category": "3.6", "percent": "35.60%", "downloads": 35274},
+            {"category": "2.6", "percent": "0.05%", "downloads": 51},
+            {"category": "3.2", "percent": "0.00%", "downloads": 2},
+        ]
+
+        # Act
+        output = pypistats._percent(data)
+
+        # Assert
+        self.assertEqual(output, expected_output)
+
+    def test__percent_recent(self):
+        # Arrange
+        data = {"last_day": 123002, "last_month": 3254221, "last_week": 761649}
+
+        # Act
+        output = pypistats._percent(data)
+
+        # Assert
+        self.assertEqual(output, data)


### PR DESCRIPTION
Fixes #11.


```console
$ pypistats --help
usage: pypistats [-h] {recent,overall,python_major,python_minor,system} ...

positional arguments:
  {recent,overall,python_major,python_minor,system}

optional arguments:
  -h, --help            show this help message and exit

$ pypistats recent numpy
| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|   509879 |   11918862 |   3014490 |


$ pypistats system numpy --last-month
| category | percent | downloads |
|----------|--------:|----------:|
| Linux    |  70.82% |   8062790 |
| Darwin   |  17.33% |   1973283 |
| Windows  |   6.26% |    713017 |
| null     |   5.56% |    633334 |
| other    |   0.02% |      2324 |
| Total    |         |  11384748 |

$ pypistats overall numpy --last-month
|    category     | percent | downloads |
|-----------------|--------:|----------:|
| with_mirrors    |  50.25% |  11497042 |
| without_mirrors |  49.75% |  11384748 |
| Total           |         |  22881790 |
```