### PR TITLE
No percent or grand total for one row

### DIFF
--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -115,6 +115,10 @@ def _grand_total(data):
     if isinstance(data, dict):
         return data
 
+    # No need when there's only one row
+    if len(data) == 1:
+        return data
+
     grand_total = sum(row["downloads"] for row in data)
     new_row = {"category": "Total", "downloads": grand_total}
     data.append(new_row)
@@ -129,7 +133,7 @@ def _percent(data):
     if isinstance(data, dict):
         return data
 
-    # No need for a total when there's only one row
+    # No need when there's only one row
     if len(data) == 1:
         return data
 

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -129,6 +129,10 @@ def _percent(data):
     if isinstance(data, dict):
         return data
 
+    # No need for a total when there's only one row
+    if len(data) == 1:
+        return data
+
     grand_total = sum(row["downloads"] for row in data)
 
     for row in data:

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -22,6 +22,7 @@ SAMPLE_DATA = [
     {"category": "null", "date": "2018-08-15", "downloads": 1019},
 ]
 SAMPLE_DATA_ONE_ROW = [{"category": "with_mirrors", "downloads": 11497042}]
+SAMPLE_DATA_RECENT = {"last_day": 123002, "last_month": 3254221, "last_week": 761649}
 
 
 class TestPypiStats(unittest.TestCase):
@@ -174,13 +175,13 @@ class TestPypiStats(unittest.TestCase):
 
     def test__sort_recent(self):
         # Arrange
-        data = {"last_day": 123002, "last_month": 3254221, "last_week": 761649}
+        data = copy.deepcopy(SAMPLE_DATA_RECENT)
 
         # Act
         output = pypistats._sort(data)
 
         # Assert
-        self.assertEqual(output, data)
+        self.assertEqual(output, SAMPLE_DATA_RECENT)
 
     def test__total(self):
         # Arrange
@@ -196,13 +197,13 @@ class TestPypiStats(unittest.TestCase):
 
     def test__total_recent(self):
         # Arrange
-        data = {"last_day": 123002, "last_month": 3254221, "last_week": 761649}
+        data = copy.deepcopy(SAMPLE_DATA_RECENT)
 
         # Act
         output = pypistats._total(data)
 
         # Assert
-        self.assertEqual(output, data)
+        self.assertEqual(output, SAMPLE_DATA_RECENT)
 
     def test__grand_total(self):
         # Arrange
@@ -229,13 +230,13 @@ class TestPypiStats(unittest.TestCase):
 
     def test__grand_total_recent(self):
         # Arrange
-        data = {"last_day": 123002, "last_month": 3254221, "last_week": 761649}
+        data = copy.deepcopy(SAMPLE_DATA_RECENT)
 
         # Act
         output = pypistats._grand_total(data)
 
         # Assert
-        self.assertEqual(output, data)
+        self.assertEqual(output, SAMPLE_DATA_RECENT)
 
     def test__percent(self):
         # Arrange
@@ -270,10 +271,10 @@ class TestPypiStats(unittest.TestCase):
 
     def test__percent_recent(self):
         # Arrange
-        data = {"last_day": 123002, "last_month": 3254221, "last_week": 761649}
+        data = copy.deepcopy(SAMPLE_DATA_RECENT)
 
         # Act
         output = pypistats._percent(data)
 
         # Assert
-        self.assertEqual(output, data)
+        self.assertEqual(output, SAMPLE_DATA_RECENT)

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -247,6 +247,16 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(output, expected_output)
 
+    def test__percent_one_row(self):
+        # Arrange
+        data = [{"category": "2.7", "downloads": 63749}]
+
+        # Act
+        output = pypistats._percent(data)
+
+        # Assert
+        self.assertEqual(output, data)
+
     def test__percent_recent(self):
         # Arrange
         data = {"last_day": 123002, "last_month": 3254221, "last_week": 761649}

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -21,6 +21,7 @@ SAMPLE_DATA = [
     {"category": "3.8", "date": "2018-08-15", "downloads": 3},
     {"category": "null", "date": "2018-08-15", "downloads": 1019},
 ]
+SAMPLE_DATA_ONE_ROW = [{"category": "with_mirrors", "downloads": 11497042}]
 
 
 class TestPypiStats(unittest.TestCase):
@@ -216,6 +217,16 @@ class TestPypiStats(unittest.TestCase):
         self.assertEqual(output[-1]["category"], "Total")
         self.assertEqual(output[-1]["downloads"], 9355317)
 
+    def test__grand_total_one_row(self):
+        # Arrange
+        data = copy.deepcopy(SAMPLE_DATA_ONE_ROW)
+
+        # Act
+        output = pypistats._grand_total(data)
+
+        # Assert
+        self.assertEqual(output, SAMPLE_DATA_ONE_ROW)
+
     def test__grand_total_recent(self):
         # Arrange
         data = {"last_day": 123002, "last_month": 3254221, "last_week": 761649}
@@ -249,13 +260,13 @@ class TestPypiStats(unittest.TestCase):
 
     def test__percent_one_row(self):
         # Arrange
-        data = [{"category": "2.7", "downloads": 63749}]
+        data = copy.deepcopy(SAMPLE_DATA_ONE_ROW)
 
         # Act
         output = pypistats._percent(data)
 
         # Assert
-        self.assertEqual(output, data)
+        self.assertEqual(output, SAMPLE_DATA_ONE_ROW)
 
     def test__percent_recent(self):
         # Arrange


### PR DESCRIPTION
# Before

```console
$ pypistats overall numpy --last-month --mirrors with
|   category   | percent | downloads |
|--------------|--------:|----------:|
| with_mirrors | 100.00% |  11497042 |
| Total        |         |  11497042 |

```

# After

```console
$ pypistats overall numpy --last-month --mirrors with
|   category   | downloads |
|--------------|----------:|
| with_mirrors |  11497042 |

```