### PR TITLE
Validate yyyy-mm-dd and yyyy-mm arguments

### DIFF
--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -4,7 +4,7 @@
 CLI with subcommands for pypistats
 """
 import argparse
-from datetime import date
+from datetime import date, datetime
 
 from dateutil.relativedelta import relativedelta
 
@@ -55,12 +55,39 @@ def subcommand(args=None, parent=subparsers):
     return decorator
 
 
+def _valid_date(date_string, date_format):
+    try:
+        datetime.strptime(date_string, date_format)
+        return date_string
+    except ValueError:
+        msg = f"Not a valid date: '{date_string}'."
+        raise argparse.ArgumentTypeError(msg)
+
+
+def _valid_yyyy_mm_dd(date_string):
+    return _valid_date(date_string, "%Y-%m-%d")
+
+
+def _valid_yyyy_mm(date_string):
+    return _valid_date(date_string, "%Y-%m")
+
+
 arg_start_date = argument(
-    "-sd", "--start-date", metavar="yyyy-mm-dd", help="Start date"
+    "-sd",
+    "--start-date",
+    metavar="yyyy-mm-dd",
+    type=_valid_yyyy_mm_dd,
+    help="Start date",
 )
-arg_end_date = argument("-ed", "--end-date", metavar="yyyy-mm-dd", help="End date")
+arg_end_date = argument(
+    "-ed", "--end-date", metavar="yyyy-mm-dd", type=_valid_yyyy_mm_dd, help="End date"
+)
 arg_month = argument(
-    "-m", "--month", metavar="yyyy-mm", help="Shortcut for -sd & -ed for a single month"
+    "-m",
+    "--month",
+    metavar="yyyy-mm",
+    type=_valid_yyyy_mm,
+    help="Shortcut for -sd & -ed for a single month",
 )
 arg_last_month = argument(
     "-l",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 """
 Unit tests for cli
 """
+import argparse
 import unittest
 
 from freezegun import freeze_time
@@ -31,3 +32,55 @@ class TestCli(unittest.TestCase):
         # Assert
         self.assertEqual(first, "2018-08-01")
         self.assertEqual(last, "2018-08-31")
+
+    def test__valid_yyyy_mm_dd(self):
+        # Arrange
+        input = "2018-07-12"
+
+        # Act
+        output = cli._valid_yyyy_mm_dd(input)
+
+        # Assert
+        self.assertEqual(input, output)
+
+    def test__valid_yyyy_mm_dd_invalid(self):
+        # Arrange
+        input = "asdfsdssd"
+
+        # Act / Assert
+        with self.assertRaises(argparse.ArgumentTypeError):
+            cli._valid_yyyy_mm_dd(input)
+
+    def test__valid_yyyy_mm_dd_invalid2(self):
+        # Arrange
+        input = "2018-99-99"
+
+        # Act / Assert
+        with self.assertRaises(argparse.ArgumentTypeError):
+            cli._valid_yyyy_mm_dd(input)
+
+    def test__valid_yyyy_mm(self):
+        # Arrange
+        input = "2018-07"
+
+        # Act
+        output = cli._valid_yyyy_mm(input)
+
+        # Assert
+        self.assertEqual(input, output)
+
+    def test__valid_yyyy_mm_invalid(self):
+        # Arrange
+        input = "dfkgjskfjgk"
+
+        # Act / Assert
+        with self.assertRaises(argparse.ArgumentTypeError):
+            cli._valid_yyyy_mm(input)
+
+    def test__valid_yyyy_mm_invalid2(self):
+        # Arrange
+        input = "2018-99"
+
+        # Act / Assert
+        with self.assertRaises(argparse.ArgumentTypeError):
+            cli._valid_yyyy_mm(input)


### PR DESCRIPTION
To validate problematic date input before making API requests. 