### PR TITLE
Added --format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ script:
  - pytest --cov pypistats
 
  # Static analysis
- - flake8 --statistics --count --verbose pypistats/ tests/
- - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then black --check --diff --verbose pypistats/ tests/; fi
+ - flake8 --statistics --count .
+ - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then black --check --diff .; fi
 
  # Test runs
  - pypistats --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
 
 install:
  - pip install -U pip
- - pip install -U flake8 freezegun pytest pytest-cov requests_mock black
+ - pip install -U flake8 freezegun pytest pytest-cov requests_mock
  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install -U black; fi
  - pip install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
 
 install:
  - pip install -U pip
- - pip install -U flake8 freezegun pytest pytest-cov requests_mock
+ - pip install -U flake8 freezegun pytest pytest-cov requests_mock black
  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install -U black; fi
  - pip install -e .
 
@@ -21,8 +21,8 @@ script:
  - pytest --cov pypistats
 
  # Static analysis
- - flake8 --statistics --count
- - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then black --check --diff .; fi
+ - flake8 --statistics --count --verbose pypistats/ tests/
+ - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then black --check --diff --verbose pypistats/ tests/; fi
 
  # Test runs
  - pypistats --help

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -15,6 +15,11 @@ __version__ = version.__version__
 
 BASE_URL = "https://pypistats.org/api/"
 
+FORMATS = (
+    "json",
+    "markdown"
+)  # only used for printing to terminal
+
 
 def pypi_stats_api(
     endpoint,

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -15,8 +15,6 @@ __version__ = version.__version__
 
 BASE_URL = "https://pypistats.org/api/"
 
-FORMATS = ("json", "markdown")  # only used for printing to terminal
-
 
 def pypi_stats_api(
     endpoint,

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -15,10 +15,7 @@ __version__ = version.__version__
 
 BASE_URL = "https://pypistats.org/api/"
 
-FORMATS = (
-    "json",
-    "markdown"
-)  # only used for printing to terminal
+FORMATS = ("json", "markdown")  # only used for printing to terminal
 
 
 def pypi_stats_api(

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -103,15 +103,26 @@ arg_daily = argument("-d", "--daily", action="store_true", help="Show daily down
     [
         argument("package"),
         argument("-p", "--period", choices=("day", "week", "month")),
-        argument("-j", "--json", action="store_true", help="Output JSON"),
+        argument("-j", "--json", action="store_true", help='Output JSON. Shortcut for "-f json".'),
+        argument("-f", "--format", default="markdown", help="The format of output. Supported: "
+                                                            f'{", ".join(pypistats.FORMATS)}. '
+                                                            'Default is "markdown".'),
     ]
 )
 def recent(args):
-    print(
-        pypistats.recent(
-            args.package, period=args.period, output="json" if args.json else "table"
-        )
-    )
+    # "table" means "markdown". legacy.
+
+    if args.json or args.format == "json":
+        output = "json"
+    elif args.format == "markdown":
+        output = "table"
+    else:
+        import warnings
+
+        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
+        output = "table"
+
+    print(pypistats.recent(args.package, period=args.period, output=output))
 
 
 @subcommand(
@@ -129,13 +140,24 @@ def recent(args):
 def overall(args):
     if args.mirrors in ["with", "without"]:
         args.mirrors = args.mirrors == "with"
+
+    if args.json or args.format == "json":
+        output = "json"
+    elif args.format == "markdown":
+        output = "table"
+    else:
+        import warnings
+
+        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
+        output = "table"
+
     print(
         pypistats.overall(
             args.package,
             mirrors=args.mirrors,
             start_date=args.start_date,
             end_date=args.end_date,
-            output="json" if args.json else "table",
+            output=output,
             total=False if args.daily else True,
         )
     )
@@ -154,13 +176,23 @@ def overall(args):
     ]
 )
 def python_major(args):
+    if args.json or args.format == "json":
+        output = "json"
+    elif args.format == "markdown":
+        output = "table"
+    else:
+        import warnings
+
+        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
+        output = "table"
+
     print(
         pypistats.python_major(
             args.package,
             version=args.version,
             start_date=args.start_date,
             end_date=args.end_date,
-            output="json" if args.json else "table",
+            output=output,
             total=False if args.daily else True,
         )
     )
@@ -179,6 +211,15 @@ def python_major(args):
     ]
 )
 def python_minor(args):
+    if args.json or args.format == "json":
+        output = "json"
+    elif args.format == "markdown":
+        output = "table"
+    else:
+        import warnings
+
+        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
+        output = "table"
 
     print(
         pypistats.python_minor(
@@ -186,7 +227,7 @@ def python_minor(args):
             version=args.version,
             start_date=args.start_date,
             end_date=args.end_date,
-            output="json" if args.json else "table",
+            output=output,
             total=False if args.daily else True,
         )
     )
@@ -205,13 +246,23 @@ def python_minor(args):
     ]
 )
 def system(args):
+    if args.json or args.format == "json":
+        output = "json"
+    elif args.format == "markdown":
+        output = "table"
+    else:
+        import warnings
+
+        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
+        output = "table"
+
     print(
         pypistats.system(
             args.package,
             os=args.os,
             start_date=args.start_date,
             end_date=args.end_date,
-            output="json" if args.json else "table",
+            output=output,
             total=False if args.daily else True,
         )
     )

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -112,7 +112,7 @@ arg_last_month = argument(
     help="Shortcut for -sd & -ed for last month",
     action="store_true",
 )
-arg_json = argument("-j", "--json", action="store_true", help="Output JSON")
+arg_json = argument("-j", "--json", action="store_true", help="Shortcut for \"-f json\"")
 arg_daily = argument("-d", "--daily", action="store_true", help="Show daily downloads")
 arg_format = argument("-f", "--format", default="markdown", choices=FORMATS, help="The format of output.")
 

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -129,7 +129,7 @@ arg_daily = argument("-d", "--daily", action="store_true", help="Show daily down
             "--format",
             default="markdown",
             choices=pypistats.FORMATS,
-            help="The format of output."
+            help="The format of output.",
         ),
     ]
 )
@@ -147,7 +147,7 @@ def recent(args):
             "--format",
             default="markdown",
             choices=pypistats.FORMATS,
-            help="The format of output."
+            help="The format of output.",
         ),
         arg_start_date,
         arg_end_date,
@@ -184,7 +184,7 @@ def overall(args):
             "--format",
             default="markdown",
             choices=pypistats.FORMATS,
-            help="The format of output."
+            help="The format of output.",
         ),
         arg_start_date,
         arg_end_date,
@@ -218,7 +218,7 @@ def python_major(args):
             "--format",
             default="markdown",
             choices=pypistats.FORMATS,
-            help="The format of output."
+            help="The format of output.",
         ),
         arg_start_date,
         arg_end_date,
@@ -252,7 +252,7 @@ def python_minor(args):
             "--format",
             default="markdown",
             choices=pypistats.FORMATS,
-            help="The format of output."
+            help="The format of output.",
         ),
         arg_start_date,
         arg_end_date,

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -123,8 +123,8 @@ arg_format = argument(
     [
         argument("package"),
         argument("-p", "--period", choices=("day", "week", "month")),
-        arg_json,
         arg_format,
+        arg_json,
     ]
 )
 def recent(args):  # pragma: no cover
@@ -136,11 +136,11 @@ def recent(args):  # pragma: no cover
         argument("package"),
         argument("--mirrors", choices=("true", "false", "with", "without")),
         arg_format,
+        arg_json,
         arg_start_date,
         arg_end_date,
         arg_month,
         arg_last_month,
-        arg_json,
         arg_daily,
     ]
 )
@@ -165,11 +165,11 @@ def overall(args):  # pragma: no cover
         argument("package"),
         argument("-v", "--version", help="eg. 2 or 3"),
         arg_format,
+        arg_json,
         arg_start_date,
         arg_end_date,
         arg_month,
         arg_last_month,
-        arg_json,
         arg_daily,
     ]
 )
@@ -191,11 +191,11 @@ def python_major(args):  # pragma: no cover
         argument("package"),
         argument("-v", "--version", help="eg. 2.7 or 3.6"),
         arg_format,
+        arg_json,
         arg_start_date,
         arg_end_date,
         arg_month,
         arg_last_month,
-        arg_json,
         arg_daily,
     ]
 )
@@ -217,11 +217,11 @@ def python_minor(args):  # pragma: no cover
         argument("package"),
         argument("-o", "--os", help="eg. windows, linux, darwin or other"),
         arg_format,
+        arg_json,
         arg_start_date,
         arg_end_date,
         arg_month,
         arg_last_month,
-        arg_json,
         arg_daily,
     ]
 )

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -115,7 +115,7 @@ arg_last_month = argument(
 arg_json = argument("-j", "--json", action="store_true", help='Shortcut for "-f json"')
 arg_daily = argument("-d", "--daily", action="store_true", help="Show daily downloads")
 arg_format = argument(
-    "-f", "--format", default="markdown", choices=FORMATS, help="The format of output."
+    "-f", "--format", default="markdown", choices=FORMATS, help="The format of output"
 )
 
 

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -113,6 +113,8 @@ arg_last_month = argument(
 arg_json = argument("-j", "--json", action="store_true", help="Output JSON")
 arg_daily = argument("-d", "--daily", action="store_true", help="Show daily downloads")
 
+FORMATS = ("json", "markdown")  # only used for printing to terminal
+
 
 @subcommand(
     [
@@ -128,7 +130,7 @@ arg_daily = argument("-d", "--daily", action="store_true", help="Show daily down
             "-f",
             "--format",
             default="markdown",
-            choices=pypistats.FORMATS,
+            choices=FORMATS,
             help="The format of output.",
         ),
     ]
@@ -146,7 +148,7 @@ def recent(args):
             "-f",
             "--format",
             default="markdown",
-            choices=pypistats.FORMATS,
+            choices=FORMATS,
             help="The format of output.",
         ),
         arg_start_date,
@@ -162,7 +164,6 @@ def overall(args):
         args.mirrors = args.mirrors == "with"
 
     _format = _define_format(args)
-
     print(
         pypistats.overall(
             args.package,
@@ -183,7 +184,7 @@ def overall(args):
             "-f",
             "--format",
             default="markdown",
-            choices=pypistats.FORMATS,
+            choices=FORMATS,
             help="The format of output.",
         ),
         arg_start_date,
@@ -196,7 +197,6 @@ def overall(args):
 )
 def python_major(args):
     _format = _define_format(args)
-
     print(
         pypistats.python_major(
             args.package,
@@ -217,7 +217,7 @@ def python_major(args):
             "-f",
             "--format",
             default="markdown",
-            choices=pypistats.FORMATS,
+            choices=FORMATS,
             help="The format of output.",
         ),
         arg_start_date,
@@ -230,7 +230,6 @@ def python_major(args):
 )
 def python_minor(args):
     _format = _define_format(args)
-
     print(
         pypistats.python_minor(
             args.package,
@@ -251,7 +250,7 @@ def python_minor(args):
             "-f",
             "--format",
             default="markdown",
-            choices=pypistats.FORMATS,
+            choices=FORMATS,
             help="The format of output.",
         ),
         arg_start_date,

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -103,10 +103,20 @@ arg_daily = argument("-d", "--daily", action="store_true", help="Show daily down
     [
         argument("package"),
         argument("-p", "--period", choices=("day", "week", "month")),
-        argument("-j", "--json", action="store_true", help='Output JSON. Shortcut for "-f json".'),
-        argument("-f", "--format", default="markdown", help="The format of output. Supported: "
-                                                            f'{", ".join(pypistats.FORMATS)}. '
-                                                            'Default is "markdown".'),
+        argument(
+            "-j",
+            "--json",
+            action="store_true",
+            help='Output JSON. Shortcut for "-f json".',
+        ),
+        argument(
+            "-f",
+            "--format",
+            default="markdown",
+            help="The format of output. Supported: "
+            f'{", ".join(pypistats.FORMATS)}. '
+            'Default is "markdown".',
+        ),
     ]
 )
 def recent(args):

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -135,7 +135,7 @@ FORMATS = ("json", "markdown")  # only used for printing to terminal
         ),
     ]
 )
-def recent(args):
+def recent(args):  # pragma: no cover
     _format = _define_format(args)
     print(pypistats.recent(args.package, period=args.period, output=_format))
 
@@ -159,7 +159,7 @@ def recent(args):
         arg_daily,
     ]
 )
-def overall(args):
+def overall(args):  # pragma: no cover
     if args.mirrors in ["with", "without"]:
         args.mirrors = args.mirrors == "with"
 
@@ -195,7 +195,7 @@ def overall(args):
         arg_daily,
     ]
 )
-def python_major(args):
+def python_major(args):  # pragma: no cover
     _format = _define_format(args)
     print(
         pypistats.python_major(
@@ -228,7 +228,7 @@ def python_major(args):
         arg_daily,
     ]
 )
-def python_minor(args):
+def python_minor(args):  # pragma: no cover
     _format = _define_format(args)
     print(
         pypistats.python_minor(
@@ -261,7 +261,7 @@ def python_minor(args):
         arg_daily,
     ]
 )
-def system(args):
+def system(args):  # pragma: no cover
     _format = _define_format(args)
 
     print(

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -126,8 +126,7 @@ arg_format = argument("-f", "--format", default="markdown", choices=FORMATS, hel
     ]
 )
 def recent(args):  # pragma: no cover
-    _format = _define_format(args)
-    print(pypistats.recent(args.package, period=args.period, output=_format))
+    print(pypistats.recent(args.package, period=args.period, output=args.format))
 
 
 @subcommand(
@@ -147,14 +146,13 @@ def overall(args):  # pragma: no cover
     if args.mirrors in ["with", "without"]:
         args.mirrors = args.mirrors == "with"
 
-    _format = _define_format(args)
     print(
         pypistats.overall(
             args.package,
             mirrors=args.mirrors,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=_format,
+            output=args.format,
             total=False if args.daily else True,
         )
     )
@@ -174,14 +172,13 @@ def overall(args):  # pragma: no cover
     ]
 )
 def python_major(args):  # pragma: no cover
-    _format = _define_format(args)
     print(
         pypistats.python_major(
             args.package,
             version=args.version,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=_format,
+            output=args.format,
             total=False if args.daily else True,
         )
     )
@@ -201,14 +198,13 @@ def python_major(args):  # pragma: no cover
     ]
 )
 def python_minor(args):  # pragma: no cover
-    _format = _define_format(args)
     print(
         pypistats.python_minor(
             args.package,
             version=args.version,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=_format,
+            output=args.format,
             total=False if args.daily else True,
         )
     )
@@ -228,15 +224,13 @@ def python_minor(args):  # pragma: no cover
     ]
 )
 def system(args):  # pragma: no cover
-    _format = _define_format(args)
-
     print(
         pypistats.system(
             args.package,
             os=args.os,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=_format,
+            output=args.format,
             total=False if args.daily else True,
         )
     )
@@ -269,6 +263,8 @@ def main():
             args.start_date, args.end_date = _month(args.month)
         if hasattr(args, "last_month") and args.last_month:
             args.start_date, args.end_date = _last_month()
+
+        args.format = _define_format(args)
 
         args.func(args)
 

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -87,6 +87,8 @@ def _define_format(args) -> str:
     return output
 
 
+FORMATS = ("json", "markdown")
+
 arg_start_date = argument(
     "-sd",
     "--start-date",
@@ -112,27 +114,15 @@ arg_last_month = argument(
 )
 arg_json = argument("-j", "--json", action="store_true", help="Output JSON")
 arg_daily = argument("-d", "--daily", action="store_true", help="Show daily downloads")
-
-FORMATS = ("json", "markdown")  # only used for printing to terminal
+arg_format = argument("-f", "--format", default="markdown", choices=FORMATS, help="The format of output.")
 
 
 @subcommand(
     [
         argument("package"),
         argument("-p", "--period", choices=("day", "week", "month")),
-        argument(
-            "-j",
-            "--json",
-            action="store_true",
-            help='Output JSON. Shortcut for "-f json".',
-        ),
-        argument(
-            "-f",
-            "--format",
-            default="markdown",
-            choices=FORMATS,
-            help="The format of output.",
-        ),
+        arg_json,
+        arg_format,
     ]
 )
 def recent(args):  # pragma: no cover
@@ -144,13 +134,7 @@ def recent(args):  # pragma: no cover
     [
         argument("package"),
         argument("--mirrors", choices=("true", "false", "with", "without")),
-        argument(
-            "-f",
-            "--format",
-            default="markdown",
-            choices=FORMATS,
-            help="The format of output.",
-        ),
+        arg_format,
         arg_start_date,
         arg_end_date,
         arg_month,
@@ -180,13 +164,7 @@ def overall(args):  # pragma: no cover
     [
         argument("package"),
         argument("-v", "--version", help="eg. 2 or 3"),
-        argument(
-            "-f",
-            "--format",
-            default="markdown",
-            choices=FORMATS,
-            help="The format of output.",
-        ),
+        arg_format,
         arg_start_date,
         arg_end_date,
         arg_month,
@@ -213,13 +191,7 @@ def python_major(args):  # pragma: no cover
     [
         argument("package"),
         argument("-v", "--version", help="eg. 2.7 or 3.6"),
-        argument(
-            "-f",
-            "--format",
-            default="markdown",
-            choices=FORMATS,
-            help="The format of output.",
-        ),
+        arg_format,
         arg_start_date,
         arg_end_date,
         arg_month,
@@ -246,13 +218,7 @@ def python_minor(args):  # pragma: no cover
     [
         argument("package"),
         argument("-o", "--os", help="eg. windows, linux, darwin or other"),
-        argument(
-            "-f",
-            "--format",
-            default="markdown",
-            choices=FORMATS,
-            help="The format of output.",
-        ),
+        arg_format,
         arg_start_date,
         arg_end_date,
         arg_month,

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -112,9 +112,11 @@ arg_last_month = argument(
     help="Shortcut for -sd & -ed for last month",
     action="store_true",
 )
-arg_json = argument("-j", "--json", action="store_true", help="Shortcut for \"-f json\"")
+arg_json = argument("-j", "--json", action="store_true", help='Shortcut for "-f json"')
 arg_daily = argument("-d", "--daily", action="store_true", help="Show daily downloads")
-arg_format = argument("-f", "--format", default="markdown", choices=FORMATS, help="The format of output.")
+arg_format = argument(
+    "-f", "--format", default="markdown", choices=FORMATS, help="The format of output."
+)
 
 
 @subcommand(

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -4,6 +4,7 @@
 CLI with subcommands for pypistats
 """
 import argparse
+import warnings
 from datetime import date, datetime
 
 from dateutil.relativedelta import relativedelta
@@ -72,6 +73,20 @@ def _valid_yyyy_mm(date_string):
     return _valid_date(date_string, "%Y-%m")
 
 
+def _define_format(args) -> str:
+    # "table" means "markdown". legacy.
+
+    if args.json or args.format == "json":
+        output = "json"
+    elif args.format == "markdown":
+        output = "table"
+    else:
+        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
+        output = "table"
+
+    return output
+
+
 arg_start_date = argument(
     "-sd",
     "--start-date",
@@ -113,32 +128,27 @@ arg_daily = argument("-d", "--daily", action="store_true", help="Show daily down
             "-f",
             "--format",
             default="markdown",
-            help="The format of output. Supported: "
-            f'{", ".join(pypistats.FORMATS)}. '
-            'Default is "markdown".',
+            choices=pypistats.FORMATS,
+            help="The format of output."
         ),
     ]
 )
 def recent(args):
-    # "table" means "markdown". legacy.
-
-    if args.json or args.format == "json":
-        output = "json"
-    elif args.format == "markdown":
-        output = "table"
-    else:
-        import warnings
-
-        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
-        output = "table"
-
-    print(pypistats.recent(args.package, period=args.period, output=output))
+    _format = _define_format(args)
+    print(pypistats.recent(args.package, period=args.period, output=_format))
 
 
 @subcommand(
     [
         argument("package"),
         argument("--mirrors", choices=("true", "false", "with", "without")),
+        argument(
+            "-f",
+            "--format",
+            default="markdown",
+            choices=pypistats.FORMATS,
+            help="The format of output."
+        ),
         arg_start_date,
         arg_end_date,
         arg_month,
@@ -151,15 +161,7 @@ def overall(args):
     if args.mirrors in ["with", "without"]:
         args.mirrors = args.mirrors == "with"
 
-    if args.json or args.format == "json":
-        output = "json"
-    elif args.format == "markdown":
-        output = "table"
-    else:
-        import warnings
-
-        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
-        output = "table"
+    _format = _define_format(args)
 
     print(
         pypistats.overall(
@@ -167,7 +169,7 @@ def overall(args):
             mirrors=args.mirrors,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=output,
+            output=_format,
             total=False if args.daily else True,
         )
     )
@@ -177,6 +179,13 @@ def overall(args):
     [
         argument("package"),
         argument("-v", "--version", help="eg. 2 or 3"),
+        argument(
+            "-f",
+            "--format",
+            default="markdown",
+            choices=pypistats.FORMATS,
+            help="The format of output."
+        ),
         arg_start_date,
         arg_end_date,
         arg_month,
@@ -186,15 +195,7 @@ def overall(args):
     ]
 )
 def python_major(args):
-    if args.json or args.format == "json":
-        output = "json"
-    elif args.format == "markdown":
-        output = "table"
-    else:
-        import warnings
-
-        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
-        output = "table"
+    _format = _define_format(args)
 
     print(
         pypistats.python_major(
@@ -202,7 +203,7 @@ def python_major(args):
             version=args.version,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=output,
+            output=_format,
             total=False if args.daily else True,
         )
     )
@@ -212,6 +213,13 @@ def python_major(args):
     [
         argument("package"),
         argument("-v", "--version", help="eg. 2.7 or 3.6"),
+        argument(
+            "-f",
+            "--format",
+            default="markdown",
+            choices=pypistats.FORMATS,
+            help="The format of output."
+        ),
         arg_start_date,
         arg_end_date,
         arg_month,
@@ -221,15 +229,7 @@ def python_major(args):
     ]
 )
 def python_minor(args):
-    if args.json or args.format == "json":
-        output = "json"
-    elif args.format == "markdown":
-        output = "table"
-    else:
-        import warnings
-
-        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
-        output = "table"
+    _format = _define_format(args)
 
     print(
         pypistats.python_minor(
@@ -237,7 +237,7 @@ def python_minor(args):
             version=args.version,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=output,
+            output=_format,
             total=False if args.daily else True,
         )
     )
@@ -247,6 +247,13 @@ def python_minor(args):
     [
         argument("package"),
         argument("-o", "--os", help="eg. windows, linux, darwin or other"),
+        argument(
+            "-f",
+            "--format",
+            default="markdown",
+            choices=pypistats.FORMATS,
+            help="The format of output."
+        ),
         arg_start_date,
         arg_end_date,
         arg_month,
@@ -256,15 +263,7 @@ def python_minor(args):
     ]
 )
 def system(args):
-    if args.json or args.format == "json":
-        output = "json"
-    elif args.format == "markdown":
-        output = "table"
-    else:
-        import warnings
-
-        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
-        output = "table"
+    _format = _define_format(args)
 
     print(
         pypistats.system(
@@ -272,7 +271,7 @@ def system(args):
             os=args.os,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=output,
+            output=_format,
             total=False if args.daily else True,
         )
     )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,14 @@ setup(
     entry_points={"console_scripts": ["pypistats = pypistats.cli:main"]},
     zip_safe=True,
     install_requires=["pytablewriter>=0.33.0", "python-dateutil", "requests"],
-    tests_require=["freezegun", "flake8", "black", "pytest", "pytest-cov", "requests_mock"],
+    tests_require=[
+        "freezegun",
+        "flake8",
+        "black",
+        "pytest",
+        "pytest-cov",
+        "requests_mock",
+    ],
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ setup(
     zip_safe=True,
     install_requires=["pytablewriter>=0.33.0", "python-dateutil", "requests"],
     tests_require=[
-        "freezegun",
-        "flake8",
         "black",
+        "flake8",
+        "freezegun",
         "pytest",
         "pytest-cov",
         "requests_mock",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     entry_points={"console_scripts": ["pypistats = pypistats.cli:main"]},
     zip_safe=True,
     install_requires=["pytablewriter>=0.33.0", "python-dateutil", "requests"],
-    tests_require=["freezegun", "flake8", "pytest", "pytest-cov", "requests_mock"],
+    tests_require=["freezegun", "flake8", "black", "pytest", "pytest-cov", "requests_mock"],
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     entry_points={"console_scripts": ["pypistats = pypistats.cli:main"]},
     zip_safe=True,
     install_requires=["pytablewriter>=0.33.0", "python-dateutil", "requests"],
+    tests_require=["freezegun", "flake8", "pytest", "pytest-cov", "requests_mock"],
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ class TestCli(unittest.TestCase):
         def __init__(self):
             self.json = False  # type: bool
             self.format = None  # type: str
-    
+
     def test__month(self):
         # Arrange
         yyyy_mm = "2018-07"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,11 @@ from pypistats import cli
 
 
 class TestCli(unittest.TestCase):
+    class __Args:
+        def __init__(self):
+            self.json = False  # type: bool
+            self.format = None  # type: str
+    
     def test__month(self):
         # Arrange
         yyyy_mm = "2018-07"
@@ -84,3 +89,35 @@ class TestCli(unittest.TestCase):
         # Act / Assert
         with self.assertRaises(argparse.ArgumentTypeError):
             cli._valid_yyyy_mm(input)
+
+    def test__define_format_default(self):
+        # Setup
+        args = self.__Args()
+        args.json = False
+        args.format = None
+
+        _format = cli._define_format(args)
+        self.assertEqual(_format, "table")
+
+    def test__define_format_json_flag(self):
+        args = self.__Args()
+        args.json = True
+
+        _format = cli._define_format(args)
+        self.assertEqual(_format, "json")
+
+    def test__define_format_json(self):
+        args = self.__Args()
+        args.json = False
+        args.format = "json"
+
+        _format = cli._define_format(args)
+        self.assertEqual(_format, "json")
+
+    def test__define_format_markdown(self):
+        args = self.__Args()
+        args.json = False
+        args.format = "markdown"
+
+        _format = cli._define_format(args)
+        self.assertEqual(_format, "table")

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -10,7 +10,7 @@ import unittest
 import requests_mock
 
 import pypistats
-from data.python_minor import DATA as PYTHON_MINOR_DATA
+from .data.python_minor import DATA as PYTHON_MINOR_DATA
 
 SAMPLE_DATA = [
     {"category": "2.6", "date": "2018-08-15", "downloads": 51},


### PR DESCRIPTION
Related to #20 

Added `--format` flag (for short, `-f`) to cli args. `--json` is kept for convenience.

```
  -j, --json            Output JSON. Shortcut for "-f json".
  -f FORMAT, --format FORMAT
                        The format of output. Supported: json, markdown.
                        Default is "markdown".
```

The default is `markdown`. The cli tool also provides a `UserWarning` if given format is not supported and will inform user that it will fallback to default, which is, again, `markdown`. An example below:

```
$ pypistats recent pyairmore -f mp3  # siriously, wth?
foo/bar/pypistats/pypistats/cli.py:132: UserWarning: Unknown format: mp3. Using "markdown".
  warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|        3 |        151 |        33 |
```

***

### Other Minor Changes

 - Verbose flake8 and black output on Travis
 - flake8 and black now checks `pypistats/` and `tests/` directory instead of whole project which makes it a little bit faster (especially black).
 - Added `tests_require` to `setup.py`.

***

The only problem is that the code I provided was not tested by `pytest` since it is not *quite* possible to both mock HTTP requests and test cli at the same time. The codebase was tested by hand :cry:. This will probably drop code coverage by ~5%. If you are strict about testing, I can find a way around (then inform me, don't merge this PR).

If you'd like to test for yourself by hand, you can clone forked copy and checkout [feat/format-arg](https://github.com/erayerdin/pypistats/tree/feat/format-arg) branch.