### PR TITLE
Reformatted "table" to "markdown"

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,23 +149,23 @@ from pprint import pprint
 
 # Call the API
 print(pypistats.recent("pillow"))
-print(pypistats.recent("pillow", "day", output="table"))
+print(pypistats.recent("pillow", "day", output="markdown"))
 pprint(pypistats.recent("pillow", "week", output="json"))
 print(pypistats.recent("pillow", "month"))
 
 print(pypistats.overall("pillow"))
-print(pypistats.overall("pillow", mirrors=True, output="table"))
+print(pypistats.overall("pillow", mirrors=True, output="markdown"))
 pprint(pypistats.overall("pillow", mirrors=False, output="json"))
 
 print(pypistats.python_major("pillow"))
-print(pypistats.python_major("pillow", version=2, output="table"))
+print(pypistats.python_major("pillow", version=2, output="markdown"))
 pprint(pypistats.python_major("pillow", version="3", output="json"))
 
 print(pypistats.python_minor("pillow"))
-print(pypistats.python_minor("pillow", version=2.7, output="table"))
+print(pypistats.python_minor("pillow", version=2.7, output="markdown"))
 pprint(pypistats.python_minor("pillow", version="3.7", output="json"))
 
 print(pypistats.system("pillow"))
-print(pypistats.system("pillow", os="darwin", output="table"))
+print(pypistats.system("pillow", os="darwin", output="markdown"))
 pprint(pypistats.system("pillow", os="linux", output="json"))
 ```

--- a/example/example.py
+++ b/example/example.py
@@ -19,20 +19,20 @@ if __name__ == "__main__":
 
     # Call the API
     print(pypistats.recent("pillow"))
-    # print(pypistats.recent("pillow", "day", output="table"))
+    # print(pypistats.recent("pillow", "day", output="markdown"))
     # pprint(pypistats.recent("pillow", "week", output="json"))
     # print(pypistats.recent("pillow", "month"))
 
     # print(pypistats.overall("pillow"))
-    # print(pypistats.overall("pillow", mirrors=True, output="table"))
+    # print(pypistats.overall("pillow", mirrors=True, output="markdown"))
     # pprint(pypistats.overall("pillow", mirrors=False, output="json"))
 
     # print(pypistats.python_major("pillow"))
-    # print(pypistats.python_major("pillow", version=2, output="table"))
+    # print(pypistats.python_major("pillow", version=2, output="markdown"))
     # pprint(pypistats.python_major("pillow", version="3", output="json"))
 
     # print(pypistats.python_minor("pillow"))
-    # print(pypistats.python_minor("pillow", version=2.7, output="table"))
+    # print(pypistats.python_minor("pillow", version=2.7, output="markdown"))
     # pprint(pypistats.python_minor("pillow", version="3.7", output="json"))
     # print(
     #     pypistats.python_minor(
@@ -46,5 +46,5 @@ if __name__ == "__main__":
     # )
 
     # print(pypistats.system("pillow"))
-    # print(pypistats.system("pillow", os="darwin", output="table"))
+    # print(pypistats.system("pillow", os="darwin", output="markdown"))
     # pprint(pypistats.system("pillow", os="linux", output="json"))

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -19,7 +19,7 @@ BASE_URL = "https://pypistats.org/api/"
 def pypi_stats_api(
     endpoint,
     params=None,
-    output="table",
+    output="markdown",
     start_date=None,
     end_date=None,
     sort=True,

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -74,17 +74,11 @@ def _valid_yyyy_mm(date_string):
 
 
 def _define_format(args) -> str:
-    # "table" means "markdown". legacy.
+    if args.json:
+        return "json"
 
-    if args.json or args.format == "json":
-        output = "json"
-    elif args.format == "markdown":
-        output = "table"
-    else:
-        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
-        output = "table"
-
-    return output
+    _format = args.format
+    return _format
 
 
 FORMATS = ("json", "markdown")

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -4,7 +4,6 @@
 CLI with subcommands for pypistats
 """
 import argparse
-import warnings
 from datetime import date, datetime
 
 from dateutil.relativedelta import relativedelta

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ class TestCli(unittest.TestCase):
     class __Args:
         def __init__(self):
             self.json = False  # type: bool
-            self.format = None  # type: str
+            self.format = "markdown"  # type: str
 
     def test__month(self):
         # Arrange
@@ -94,10 +94,9 @@ class TestCli(unittest.TestCase):
         # Setup
         args = self.__Args()
         args.json = False
-        args.format = None
 
         _format = cli._define_format(args)
-        self.assertEqual(_format, "table")
+        self.assertEqual(_format, "markdown")
 
     def test__define_format_json_flag(self):
         args = self.__Args()
@@ -120,4 +119,4 @@ class TestCli(unittest.TestCase):
         args.format = "markdown"
 
         _format = cli._define_format(args)
-        self.assertEqual(_format, "table")
+        self.assertEqual(_format, "markdown")


### PR DESCRIPTION
Reformatted "table" strings to "markdown" alongside with editing the logic of `_define_format` method in `cli.py`.

Also changed `README.md` respectively.