### PR TITLE
Reformatted output to format

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,23 +149,23 @@ from pprint import pprint
 
 # Call the API
 print(pypistats.recent("pillow"))
-print(pypistats.recent("pillow", "day", output="table"))
+print(pypistats.recent("pillow", "day", output="markdown"))
 pprint(pypistats.recent("pillow", "week", output="json"))
 print(pypistats.recent("pillow", "month"))
 
 print(pypistats.overall("pillow"))
-print(pypistats.overall("pillow", mirrors=True, output="table"))
+print(pypistats.overall("pillow", mirrors=True, output="markdown"))
 pprint(pypistats.overall("pillow", mirrors=False, output="json"))
 
 print(pypistats.python_major("pillow"))
-print(pypistats.python_major("pillow", version=2, output="table"))
+print(pypistats.python_major("pillow", version=2, output="markdown"))
 pprint(pypistats.python_major("pillow", version="3", output="json"))
 
 print(pypistats.python_minor("pillow"))
-print(pypistats.python_minor("pillow", version=2.7, output="table"))
+print(pypistats.python_minor("pillow", version=2.7, output="markdown"))
 pprint(pypistats.python_minor("pillow", version="3.7", output="json"))
 
 print(pypistats.system("pillow"))
-print(pypistats.system("pillow", os="darwin", output="table"))
+print(pypistats.system("pillow", os="darwin", output="markdown"))
 pprint(pypistats.system("pillow", os="linux", output="json"))
 ```

--- a/README.md
+++ b/README.md
@@ -149,23 +149,23 @@ from pprint import pprint
 
 # Call the API
 print(pypistats.recent("pillow"))
-print(pypistats.recent("pillow", "day", output="markdown"))
-pprint(pypistats.recent("pillow", "week", output="json"))
+print(pypistats.recent("pillow", "day", format="markdown"))
+pprint(pypistats.recent("pillow", "week", format="json"))
 print(pypistats.recent("pillow", "month"))
 
 print(pypistats.overall("pillow"))
-print(pypistats.overall("pillow", mirrors=True, output="markdown"))
-pprint(pypistats.overall("pillow", mirrors=False, output="json"))
+print(pypistats.overall("pillow", mirrors=True, format="markdown"))
+pprint(pypistats.overall("pillow", mirrors=False, format="json"))
 
 print(pypistats.python_major("pillow"))
-print(pypistats.python_major("pillow", version=2, output="markdown"))
-pprint(pypistats.python_major("pillow", version="3", output="json"))
+print(pypistats.python_major("pillow", version=2, format="markdown"))
+pprint(pypistats.python_major("pillow", version="3", format="json"))
 
 print(pypistats.python_minor("pillow"))
-print(pypistats.python_minor("pillow", version=2.7, output="markdown"))
-pprint(pypistats.python_minor("pillow", version="3.7", output="json"))
+print(pypistats.python_minor("pillow", version=2.7, format="markdown"))
+pprint(pypistats.python_minor("pillow", version="3.7", format="json"))
 
 print(pypistats.system("pillow"))
-print(pypistats.system("pillow", os="darwin", output="markdown"))
-pprint(pypistats.system("pillow", os="linux", output="json"))
+print(pypistats.system("pillow", os="darwin", format="markdown"))
+pprint(pypistats.system("pillow", os="linux", format="json"))
 ```

--- a/example/example.py
+++ b/example/example.py
@@ -19,24 +19,24 @@ if __name__ == "__main__":
 
     # Call the API
     print(pypistats.recent("pillow"))
-    # print(pypistats.recent("pillow", "day", output="markdown"))
-    # pprint(pypistats.recent("pillow", "week", output="json"))
+    # print(pypistats.recent("pillow", "day", format="markdown"))
+    # pprint(pypistats.recent("pillow", "week", format="json"))
     # print(pypistats.recent("pillow", "month"))
 
     # print(pypistats.overall("pillow"))
-    # print(pypistats.overall("pillow", mirrors=True, output="markdown"))
-    # pprint(pypistats.overall("pillow", mirrors=False, output="json"))
+    # print(pypistats.overall("pillow", mirrors=True, format="markdown"))
+    # pprint(pypistats.overall("pillow", mirrors=False, format="json"))
 
     # print(pypistats.python_major("pillow"))
-    # print(pypistats.python_major("pillow", version=2, output="markdown"))
-    # pprint(pypistats.python_major("pillow", version="3", output="json"))
+    # print(pypistats.python_major("pillow", version=2, format="markdown"))
+    # pprint(pypistats.python_major("pillow", version="3", format="json"))
 
     # print(pypistats.python_minor("pillow"))
-    # print(pypistats.python_minor("pillow", version=2.7, output="markdown"))
-    # pprint(pypistats.python_minor("pillow", version="3.7", output="json"))
+    # print(pypistats.python_minor("pillow", version=2.7, format="markdown"))
+    # pprint(pypistats.python_minor("pillow", version="3.7", format="json"))
     # print(
     #     pypistats.python_minor(
-    #         "pillow", output="json", start_date="2018-09-20", end_date="2018-09-22"
+    #         "pillow", format="json", start_date="2018-09-20", end_date="2018-09-22"
     #     )
     # )
     # print(
@@ -46,5 +46,5 @@ if __name__ == "__main__":
     # )
 
     # print(pypistats.system("pillow"))
-    # print(pypistats.system("pillow", os="darwin", output="markdown"))
-    # pprint(pypistats.system("pillow", os="linux", output="json"))
+    # print(pypistats.system("pillow", os="darwin", format="markdown"))
+    # pprint(pypistats.system("pillow", os="linux", format="json"))

--- a/example/example.py
+++ b/example/example.py
@@ -19,20 +19,20 @@ if __name__ == "__main__":
 
     # Call the API
     print(pypistats.recent("pillow"))
-    # print(pypistats.recent("pillow", "day", output="table"))
+    # print(pypistats.recent("pillow", "day", output="markdown"))
     # pprint(pypistats.recent("pillow", "week", output="json"))
     # print(pypistats.recent("pillow", "month"))
 
     # print(pypistats.overall("pillow"))
-    # print(pypistats.overall("pillow", mirrors=True, output="table"))
+    # print(pypistats.overall("pillow", mirrors=True, output="markdown"))
     # pprint(pypistats.overall("pillow", mirrors=False, output="json"))
 
     # print(pypistats.python_major("pillow"))
-    # print(pypistats.python_major("pillow", version=2, output="table"))
+    # print(pypistats.python_major("pillow", version=2, output="markdown"))
     # pprint(pypistats.python_major("pillow", version="3", output="json"))
 
     # print(pypistats.python_minor("pillow"))
-    # print(pypistats.python_minor("pillow", version=2.7, output="table"))
+    # print(pypistats.python_minor("pillow", version=2.7, output="markdown"))
     # pprint(pypistats.python_minor("pillow", version="3.7", output="json"))
     # print(
     #     pypistats.python_minor(
@@ -46,5 +46,5 @@ if __name__ == "__main__":
     # )
 
     # print(pypistats.system("pillow"))
-    # print(pypistats.system("pillow", os="darwin", output="table"))
+    # print(pypistats.system("pillow", os="darwin", output="markdown"))
     # pprint(pypistats.system("pillow", os="linux", output="json"))

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -19,7 +19,7 @@ BASE_URL = "https://pypistats.org/api/"
 def pypi_stats_api(
     endpoint,
     params=None,
-    output="table",
+    output="markdown",
     start_date=None,
     end_date=None,
     sort=True,

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -19,7 +19,7 @@ BASE_URL = "https://pypistats.org/api/"
 def pypi_stats_api(
     endpoint,
     params=None,
-    output="markdown",
+    format="markdown",
     start_date=None,
     end_date=None,
     sort=True,
@@ -45,10 +45,10 @@ def pypi_stats_api(
     if total:
         res["data"] = _total(res["data"])
 
-    if output == "json":
+    if format == "json":
         return json.dumps(res)
 
-    # These only for table
+    # These only for markdown
     data = res["data"]
     if sort:
         data = _sort(data)

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -74,17 +74,11 @@ def _valid_yyyy_mm(date_string):
 
 
 def _define_format(args) -> str:
-    # "table" means "markdown". legacy.
+    if args.json:
+        return "json"
 
-    if args.json or args.format == "json":
-        output = "json"
-    elif args.format == "markdown":
-        output = "table"
-    else:
-        warnings.warn(f'Unknown format: {args.format}. Using "markdown".')
-        output = "table"
-
-    return output
+    _format = args.format
+    return _format
 
 
 FORMATS = ("json", "markdown")

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -121,7 +121,7 @@ arg_format = argument(
     ]
 )
 def recent(args):  # pragma: no cover
-    print(pypistats.recent(args.package, period=args.period, output=args.format))
+    print(pypistats.recent(args.package, period=args.period, format=args.format))
 
 
 @subcommand(
@@ -147,7 +147,7 @@ def overall(args):  # pragma: no cover
             mirrors=args.mirrors,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=args.format,
+            format=args.format,
             total=False if args.daily else True,
         )
     )
@@ -173,7 +173,7 @@ def python_major(args):  # pragma: no cover
             version=args.version,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=args.format,
+            format=args.format,
             total=False if args.daily else True,
         )
     )
@@ -199,7 +199,7 @@ def python_minor(args):  # pragma: no cover
             version=args.version,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=args.format,
+            format=args.format,
             total=False if args.daily else True,
         )
     )
@@ -225,7 +225,7 @@ def system(args):  # pragma: no cover
             os=args.os,
             start_date=args.start_date,
             end_date=args.end_date,
-            output=args.format,
+            format=args.format,
             total=False if args.daily else True,
         )
     )

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -4,7 +4,6 @@
 CLI with subcommands for pypistats
 """
 import argparse
-import warnings
 from datetime import date, datetime
 
 from dateutil.relativedelta import relativedelta

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -76,8 +76,7 @@ def _define_format(args) -> str:
     if args.json:
         return "json"
 
-    _format = args.format
-    return _format
+    return args.format
 
 
 FORMATS = ("json", "markdown")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ class TestCli(unittest.TestCase):
     class __Args:
         def __init__(self):
             self.json = False  # type: bool
-            self.format = None  # type: str
+            self.format = "markdown"  # type: str
 
     def test__month(self):
         # Arrange
@@ -94,10 +94,9 @@ class TestCli(unittest.TestCase):
         # Setup
         args = self.__Args()
         args.json = False
-        args.format = None
 
         _format = cli._define_format(args)
-        self.assertEqual(_format, "table")
+        self.assertEqual(_format, "markdown")
 
     def test__define_format_json_flag(self):
         args = self.__Args()
@@ -120,4 +119,4 @@ class TestCli(unittest.TestCase):
         args.format = "markdown"
 
         _format = cli._define_format(args)
-        self.assertEqual(_format, "table")
+        self.assertEqual(_format, "markdown")

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -308,7 +308,7 @@ class TestPypiStats(unittest.TestCase):
         # Act
         with requests_mock.Mocker() as m:
             m.get(mocked_url, text=mocked_response)
-            output = pypistats.recent(package, period="day", output="json")
+            output = pypistats.recent(package, period="day", format="json")
 
         # Assert
         # Should not raise any errors eg. TypeError


### PR DESCRIPTION
Reformatted `output` to `format` on `pypi_stats_api` method with related `README.md` changes.

For god's sake, I thought a simply `rebase` would not include ` #26, but apparently it did. I think this also includes #26.