### PR TITLE
Added RST Format

### DIFF
--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -169,41 +169,9 @@ def _custom_list(input_list, special_item, default_value, special_value):
 def _tabulate(data, format="markdown"):
     """Return data in specified format"""
 
-    format_methods = {"markdown": _tabulate_markdown, "rst": _tabulate_rst}
+    format_writers = {"markdown": MarkdownTableWriter, "rst": RstSimpleTableWriter}
 
-    return format_methods[format](data)
-
-
-def _tabulate_rst(data):
-    """Return data in RST table."""
-    writer = RstSimpleTableWriter()
-    writer.margin = 1
-
-    if isinstance(data, dict):
-        header_list = list(data.keys())
-        writer.value_matrix = [data]
-    else:  # isinstance(data, list):
-        header_list = sorted(set().union(*(d.keys() for d in data)))
-        writer.value_matrix = data
-
-    # Move downloads last
-    header_list.append("downloads")
-    header_list.remove("downloads")
-    writer.header_list = header_list
-
-    # Custom alignment and format
-    writer.align_list = _custom_list(header_list, "percent", Align.AUTO, Align.RIGHT)
-    writer.format_list = _custom_list(
-        header_list, "downloads", Format.NONE, Format.THOUSAND_SEPARATOR
-    )
-
-    return writer.dumps()
-
-
-def _tabulate_markdown(data):
-    """Return data in markdown table"""
-
-    writer = MarkdownTableWriter()
+    writer = format_writers[format]()
     writer.margin = 1
 
     if isinstance(data, dict):

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -7,7 +7,7 @@ https://pypistats.org/api
 import json
 
 import requests
-from pytablewriter import Align, Format, MarkdownTableWriter
+from pytablewriter import Align, Format, MarkdownTableWriter, RstSimpleTableWriter
 
 from . import version
 
@@ -56,7 +56,7 @@ def pypi_stats_api(
     data = _percent(data)
     data = _grand_total(data)
 
-    return _tabulate(data)
+    return _tabulate(data, format)
 
 
 def _filter(data, start_date=None, end_date=None):
@@ -166,8 +166,42 @@ def _custom_list(input_list, special_item, default_value, special_value):
     return new_list
 
 
-def _tabulate(data):
-    """Return data in table"""
+def _tabulate(data, format="markdown"):
+    """Return data in specified format"""
+
+    format_methods = {"markdown": _tabulate_markdown, "rst": _tabulate_rst}
+
+    return format_methods[format](data)
+
+
+def _tabulate_rst(data):
+    """Return data in RST table."""
+    writer = RstSimpleTableWriter()
+    writer.margin = 1
+
+    if isinstance(data, dict):
+        header_list = list(data.keys())
+        writer.value_matrix = [data]
+    else:  # isinstance(data, list):
+        header_list = sorted(set().union(*(d.keys() for d in data)))
+        writer.value_matrix = data
+
+    # Move downloads last
+    header_list.append("downloads")
+    header_list.remove("downloads")
+    writer.header_list = header_list
+
+    # Custom alignment and format
+    writer.align_list = _custom_list(header_list, "percent", Align.AUTO, Align.RIGHT)
+    writer.format_list = _custom_list(
+        header_list, "downloads", Format.NONE, Format.THOUSAND_SEPARATOR
+    )
+
+    return writer.dumps()
+
+
+def _tabulate_markdown(data):
+    """Return data in markdown table"""
 
     writer = MarkdownTableWriter()
     writer.margin = 1

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -79,7 +79,7 @@ def _define_format(args) -> str:
     return args.format
 
 
-FORMATS = ("json", "markdown")
+FORMATS = ("json", "markdown", "rst")
 
 arg_start_date = argument(
     "-sd",

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -130,7 +130,7 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(param, "&version=3.7")
 
-    def test__tabulate(self):
+    def test__tabulate_noarg(self):
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA)
         expected_output = """
@@ -173,7 +173,7 @@ class TestPypiStats(unittest.TestCase):
 """
 
         # Act
-        output = pypistats._tabulate_markdown(data)
+        output = pypistats._tabulate(data, format="markdown")
 
         # Assert
         self.assertEqual(output.strip(), expected_output.strip())
@@ -201,7 +201,7 @@ class TestPypiStats(unittest.TestCase):
 """  # noqa: W291
 
         # Act
-        output = pypistats._tabulate_rst(data)
+        output = pypistats._tabulate(data, format="rst")
 
         # Assert
         self.assertEqual(output.strip(), expected_output.strip())

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -198,7 +198,7 @@ class TestPypiStats(unittest.TestCase):
           3.8    2018-08-15            3 
      null        2018-08-15        1,019 
     ==========  ============  ===========
-"""
+"""  # noqa: W291
 
         # Act
         output = pypistats._tabulate_rst(data)

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -154,6 +154,58 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(output.strip(), expected_output.strip())
 
+    def test__tabulate_markdown(self):
+        # Arrange
+        data = copy.deepcopy(SAMPLE_DATA)
+        expected_output = """
+| category |    date    | downloads |
+|----------|------------|----------:|
+|      2.6 | 2018-08-15 |        51 |
+|      2.7 | 2018-08-15 |    63,749 |
+|      3.2 | 2018-08-15 |         2 |
+|      3.3 | 2018-08-15 |        40 |
+|      3.4 | 2018-08-15 |     6,095 |
+|      3.5 | 2018-08-15 |    20,358 |
+|      3.6 | 2018-08-15 |    35,274 |
+|      3.7 | 2018-08-15 |     6,595 |
+|      3.8 | 2018-08-15 |         3 |
+| null     | 2018-08-15 |     1,019 |
+"""
+
+        # Act
+        output = pypistats._tabulate_markdown(data)
+
+        # Assert
+        self.assertEqual(output.strip(), expected_output.strip())
+
+    def test__tabulate_rst(self):
+        # Arrange
+        data = copy.deepcopy(SAMPLE_DATA)
+        expected_output = """
+.. table:: 
+
+    ==========  ============  ===========
+     category       date       downloads 
+    ==========  ============  ===========
+          2.6    2018-08-15           51 
+          2.7    2018-08-15       63,749 
+          3.2    2018-08-15            2 
+          3.3    2018-08-15           40 
+          3.4    2018-08-15        6,095 
+          3.5    2018-08-15       20,358 
+          3.6    2018-08-15       35,274 
+          3.7    2018-08-15        6,595 
+          3.8    2018-08-15            3 
+     null        2018-08-15        1,019 
+    ==========  ============  ===========
+"""
+
+        # Act
+        output = pypistats._tabulate_rst(data)
+
+        # Assert
+        self.assertEqual(output.strip(), expected_output.strip())
+
     def test__sort(self):
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA)


### PR DESCRIPTION
Added RST format both programmatic and cli side.

Also I have to say that on the line 201 of file `tests/test_pypistats.py`, I added an inline comment:

    # noqa: W291

flake8 complains because that string contains some whitespaces at the end or beginning of the line, but that string is a valid RST string so it should ignore that.