### PR TITLE
Show CLI defaults for --help

### DIFF
--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -47,7 +47,11 @@ def subcommand(args=None, parent=subparsers):
 
     def decorator(func):
         func2 = getattr(pypistats, func.__name__)
-        parser = parent.add_parser(func.__name__, description=func2.__doc__)
+        parser = parent.add_parser(
+            func.__name__,
+            description=func2.__doc__,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
         for arg in args:
             parser.add_argument(*arg[0], **arg[1])
         parser.set_defaults(func=func)


### PR DESCRIPTION
# Before

```console
usage: pypistats recent [-h] [-p {day,week,month}] [-f {json,markdown,rst}]
                        [-j]
                        package

Retrieve the aggregate download quantities for the last day/week/month

positional arguments:
  package

optional arguments:
  -h, --help            show this help message and exit
  -p {day,week,month}, --period {day,week,month}
  -f {json,markdown,rst}, --format {json,markdown,rst}
                        The format of output
  -j, --json            Shortcut for "-f json"
```

# After

```console
usage: pypistats recent [-h] [-p {day,week,month}] [-f {json,markdown,rst}]
                        [-j]
                        package

Retrieve the aggregate download quantities for the last day/week/month

positional arguments:
  package

optional arguments:
  -h, --help            show this help message and exit
  -p {day,week,month}, --period {day,week,month}
  -f {json,markdown,rst}, --format {json,markdown,rst}
                        The format of output (default: markdown)
  -j, --json            Shortcut for "-f json" (default: False)
```