### PR TITLE
More tests and a fix a bug

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma:
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+    def main

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ matrix:
 
 install:
  - pip install -U pip
- - pip install -U flake8 freezegun pytest pytest-cov requests_mock
- - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install -U black; fi
+ - pip install -U black flake8 freezegun pytest pytest-cov requests_mock
  - pip install -e .
 
 script:
@@ -22,7 +21,7 @@ script:
 
  # Static analysis
  - flake8 --statistics --count .
- - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then black --check --diff .; fi
+ - black --check --diff .
 
  # Test runs
  - pypistats --help

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -198,10 +198,15 @@ def _tabulate(data, format="markdown"):
     writer.header_list = header_list
 
     # Custom alignment and format
-    writer.align_list = _custom_list(header_list, "percent", Align.AUTO, Align.RIGHT)
-    writer.format_list = _custom_list(
-        header_list, "downloads", Format.NONE, Format.THOUSAND_SEPARATOR
-    )
+    if header_list[0] in ["last_day", "last_month", "last_week"]:
+        # Special case for 'recent'
+        writer.align_list =  len(header_list) * [Align.AUTO]
+        writer.format_list =  len(header_list) * [Format.THOUSAND_SEPARATOR]
+    else:
+        writer.align_list = _custom_list(header_list, "percent", Align.AUTO, Align.RIGHT)
+        writer.format_list = _custom_list(
+            header_list, "downloads", Format.NONE, Format.THOUSAND_SEPARATOR
+        )
 
     return writer.dumps()
 

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -54,7 +54,7 @@ def pypi_stats_api(
     if format == "json":
         return json.dumps(res)
 
-    # These only for markdown
+    # These only for tables, like markdown and rst
     data = res["data"]
     if sort:
         data = _sort(data)

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -200,10 +200,12 @@ def _tabulate(data, format="markdown"):
     # Custom alignment and format
     if header_list[0] in ["last_day", "last_month", "last_week"]:
         # Special case for 'recent'
-        writer.align_list =  len(header_list) * [Align.AUTO]
-        writer.format_list =  len(header_list) * [Format.THOUSAND_SEPARATOR]
+        writer.align_list = len(header_list) * [Align.AUTO]
+        writer.format_list = len(header_list) * [Format.THOUSAND_SEPARATOR]
     else:
-        writer.align_list = _custom_list(header_list, "percent", Align.AUTO, Align.RIGHT)
+        writer.align_list = _custom_list(
+            header_list, "percent", Align.AUTO, Align.RIGHT
+        )
         writer.format_list = _custom_list(
             header_list, "downloads", Format.NONE, Format.THOUSAND_SEPARATOR
         )

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -439,3 +439,30 @@ class TestPypiStats(unittest.TestCase):
         # Should not raise any errors eg. TypeError
         json.loads(output)
         self.assertEqual(output, mocked_response)
+
+    def test_overall(self):
+        # Arrange
+        package = "pip"
+        mocked_url = "https://pypistats.org/api/packages/pip/overall"
+        mocked_response = """{
+            "data": [
+                {"category": "with_mirrors", "downloads": 286030162},
+                {"category": "without_mirrors", "downloads": 284455414}
+            ],
+            "package": "pip",
+            "type": "overall_downloads"
+        }""".strip()
+        expected_output = """
+|    category     | percent |  downloads  |
+|-----------------|--------:|------------:|
+| with_mirrors    |  50.14% | 286,030,162 |
+| without_mirrors |  49.86% | 284,455,414 |
+| Total           |         | 570,485,576 |"""
+
+        # Act
+        with requests_mock.Mocker() as m:
+            m.get(mocked_url, text=mocked_response)
+            output = pypistats.overall(package)
+
+        # Assert
+        self.assertEqual(output.strip(), expected_output.strip())

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -463,30 +463,28 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(output.strip(), expected_output.strip())
 
-    def test_overall_tabular(self):
+    def test_overall_tabular_start_date(self):
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/overall"
         mocked_response = """{
-            "data": [
-                {"category": "with_mirrors", "downloads": 286030162},
-                {"category": "without_mirrors", "downloads": 284455414}
-            ],
-            "package": "pip",
-            "type": "overall_downloads"
+          "data": [
+            {"category": "without_mirrors", "date": "2018-11-01", "downloads": 2295765},
+            {"category": "without_mirrors", "date": "2018-11-02", "downloads": 2297591}
+          ],
+          "package": "pip",
+          "type": "overall_downloads"
         }""".strip()
         expected_output = """
-|    category     | percent |  downloads  |
-|-----------------|--------:|------------:|
-| with_mirrors    |  50.14% | 286,030,162 |
-| without_mirrors |  49.86% | 284,455,414 |
-| Total           |         | 570,485,576 |
+|    category     | downloads |
+|-----------------|----------:|
+| without_mirrors | 2,297,591 |
 """
 
         # Act
         with requests_mock.Mocker() as m:
             m.get(mocked_url, text=mocked_response)
-            output = pypistats.overall(package)
+            output = pypistats.overall(package, mirrors=False, start_date="2018-11-02")
 
         # Assert
         self.assertEqual(output.strip(), expected_output.strip())

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -440,6 +440,29 @@ class TestPypiStats(unittest.TestCase):
         json.loads(output)
         self.assertEqual(output, mocked_response)
 
+    def test_recent_tabular(self):
+        # Arrange
+        package = "pip"
+        mocked_url = "https://pypistats.org/api/packages/pip/recent"
+        mocked_response = """{
+            "data":
+                {"last_day": 2295765, "last_month": 67759913, "last_week": 15706750},
+            "package": "pip", "type": "recent_downloads"
+        }""".strip()
+        expected_output = """
+| last_day | last_month | last_week |
+|---------:|-----------:|----------:|
+|  2295765 |   67759913 |  15706750 |
+"""
+
+        # Act
+        with requests_mock.Mocker() as m:
+            m.get(mocked_url, text=mocked_response)
+            output = pypistats.recent(package)
+
+        # Assert
+        self.assertEqual(output.strip(), expected_output.strip())
+
     def test_overall_tabular(self):
         # Arrange
         package = "pip"

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -450,9 +450,9 @@ class TestPypiStats(unittest.TestCase):
             "package": "pip", "type": "recent_downloads"
         }""".strip()
         expected_output = """
-| last_day | last_month | last_week |
-|---------:|-----------:|----------:|
-|  2295765 |   67759913 |  15706750 |
+| last_day  | last_month | last_week  |
+|----------:|-----------:|-----------:|
+| 2,295,765 | 67,759,913 | 15,706,750 |
 """
 
         # Act

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -440,7 +440,7 @@ class TestPypiStats(unittest.TestCase):
         json.loads(output)
         self.assertEqual(output, mocked_response)
 
-    def test_overall(self):
+    def test_overall_tabular(self):
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/overall"
@@ -457,12 +457,47 @@ class TestPypiStats(unittest.TestCase):
 |-----------------|--------:|------------:|
 | with_mirrors    |  50.14% | 286,030,162 |
 | without_mirrors |  49.86% | 284,455,414 |
-| Total           |         | 570,485,576 |"""
+| Total           |         | 570,485,576 |
+"""
 
         # Act
         with requests_mock.Mocker() as m:
             m.get(mocked_url, text=mocked_response)
             output = pypistats.overall(package)
+
+        # Assert
+        self.assertEqual(output.strip(), expected_output.strip())
+
+    def test_system_tabular(self):
+        # Arrange
+        package = "pip"
+        mocked_url = "https://pypistats.org/api/packages/pip/system"
+        mocked_response = """{
+            "data": [
+                {"category": "Darwin", "downloads": 10734594},
+                {"category": "Linux", "downloads": 236502274},
+                {"category": "null", "downloads": 30579325},
+                {"category": "other", "downloads": 111243},
+                {"category": "Windows", "downloads": 6527978}
+            ],
+            "package": "pip",
+            "type": "system_downloads"
+        }""".strip()
+        expected_output = """
+| category | percent |  downloads  |
+|----------|--------:|------------:|
+| Linux    |  83.14% | 236,502,274 |
+| null     |  10.75% |  30,579,325 |
+| Darwin   |   3.77% |  10,734,594 |
+| Windows  |   2.29% |   6,527,978 |
+| other    |   0.04% |     111,243 |
+| Total    |         | 284,455,414 |
+"""
+
+        # Act
+        with requests_mock.Mocker() as m:
+            m.get(mocked_url, text=mocked_response)
+            output = pypistats.system(package)
 
         # Assert
         self.assertEqual(output.strip(), expected_output.strip())


### PR DESCRIPTION
* Add extra tests and coverage, and in the process fix a bug (testing works!):

  * Comma-separated thousands missing for `recent`, because its table headers are different to all the rest, which are standard

# Before
```console
pypistats recent pip
| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|  1799469 |   67307635 |  15490986 |
```

# After
```console
$ pypistats recent pip
| last_day  | last_month | last_week  |
|----------:|-----------:|-----------:|
| 1,799,469 | 67,307,635 | 15,490,986 |
```

* Also run Black for both 3.6 and 3.7 on the CI
* Exclude `__main__` and `main()` from coverage
