### PR TITLE
More tests

### DIFF
--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -489,7 +489,7 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(output.strip(), expected_output.strip())
 
-    def test_python_minor_json(self):
+    def test_python_major_json(self):
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/python_major"
@@ -516,6 +516,51 @@ class TestPypiStats(unittest.TestCase):
         with requests_mock.Mocker() as m:
             m.get(mocked_url, text=mocked_response)
             output = pypistats.python_major(package, format="json")
+
+        # Assert
+        self.assertEqual(json.loads(output), json.loads(expected_output))
+
+    def test_python_minor_json(self):
+        # Arrange
+        package = "pip"
+        mocked_url = "https://pypistats.org/api/packages/pip/python_minor"
+        mocked_response = """{
+            "data": [
+                {"category": "2.6", "date": "2018-11-01", "downloads": 6863},
+                {"category": "2.7", "date": "2018-11-01", "downloads": 2001481},
+                {"category": "3.2", "date": "2018-11-01", "downloads": 9},
+                {"category": "3.3", "date": "2018-11-01", "downloads": 414},
+                {"category": "3.4", "date": "2018-11-01", "downloads": 62166},
+                {"category": "3.5", "date": "2018-11-01", "downloads": 79425},
+                {"category": "3.6", "date": "2018-11-01", "downloads": 112266},
+                {"category": "3.7", "date": "2018-11-01", "downloads": 25961},
+                {"category": "3.8", "date": "2018-11-01", "downloads": 58},
+                {"category": "null", "date": "2018-11-01", "downloads": 7122}
+            ],
+            "package": "pip",
+            "type": "python_minor_downloads"
+        }"""
+        expected_output = """{
+            "data": [
+                {"category": "2.6", "downloads": 6863},
+                {"category": "2.7", "downloads": 2001481},
+                {"category": "3.2", "downloads": 9},
+                {"category": "3.3", "downloads": 414},
+                {"category": "3.4", "downloads": 62166},
+                {"category": "3.5", "downloads": 79425},
+                {"category": "3.6", "downloads": 112266},
+                {"category": "3.7", "downloads": 25961},
+                {"category": "3.8", "downloads": 58},
+                {"category": "null", "downloads": 7122}
+            ],
+            "package": "pip",
+            "type": "python_minor_downloads"
+        }"""
+
+        # Act
+        with requests_mock.Mocker() as m:
+            m.get(mocked_url, text=mocked_response)
+            output = pypistats.python_minor(package, format="json")
 
         # Assert
         self.assertEqual(json.loads(output), json.loads(expected_output))

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -489,6 +489,37 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(output.strip(), expected_output.strip())
 
+    def test_python_minor_json(self):
+        # Arrange
+        package = "pip"
+        mocked_url = "https://pypistats.org/api/packages/pip/python_major"
+        mocked_response = """{
+            "data": [
+                {"category": "2", "date": "2018-11-01", "downloads": 2008344},
+                {"category": "3", "date": "2018-11-01", "downloads": 280299},
+                {"category": "null", "date": "2018-11-01", "downloads": 7122}
+            ],
+            "package": "pip",
+            "type": "python_major_downloads"
+        }"""
+        expected_output = """{
+            "data": [
+                {"category": "2", "downloads": 2008344},
+                {"category": "3", "downloads": 280299},
+                {"category": "null", "downloads": 7122}
+            ],
+            "package": "pip",
+            "type": "python_major_downloads"
+        }"""
+
+        # Act
+        with requests_mock.Mocker() as m:
+            m.get(mocked_url, text=mocked_response)
+            output = pypistats.python_major(package, format="json")
+
+        # Assert
+        self.assertEqual(json.loads(output), json.loads(expected_output))
+
     def test_system_tabular(self):
         # Arrange
         package = "pip"

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -428,7 +428,7 @@ class TestPypiStats(unittest.TestCase):
         mocked_url = "https://pypistats.org/api/packages/pip/recent?&period=day"
         mocked_response = """
         {"data": {"last_day": 1956060}, "package": "pip", "type": "recent_downloads"}
-        """.strip()
+        """
 
         # Act
         with requests_mock.Mocker() as m:
@@ -438,7 +438,7 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         # Should not raise any errors eg. TypeError
         json.loads(output)
-        self.assertEqual(output, mocked_response)
+        self.assertEqual(json.loads(output), json.loads(mocked_response))
 
     def test_recent_tabular(self):
         # Arrange
@@ -448,7 +448,7 @@ class TestPypiStats(unittest.TestCase):
             "data":
                 {"last_day": 2295765, "last_month": 67759913, "last_week": 15706750},
             "package": "pip", "type": "recent_downloads"
-        }""".strip()
+        }"""
         expected_output = """
 | last_day  | last_month | last_week  |
 |----------:|-----------:|-----------:|
@@ -474,7 +474,7 @@ class TestPypiStats(unittest.TestCase):
           ],
           "package": "pip",
           "type": "overall_downloads"
-        }""".strip()
+        }"""
         expected_output = """
 |    category     | downloads |
 |-----------------|----------:|
@@ -534,7 +534,7 @@ class TestPypiStats(unittest.TestCase):
             ],
             "package": "pip",
             "type": "system_downloads"
-        }""".strip()
+        }"""
         expected_output = """
 | category | percent |  downloads  |
 |----------|--------:|------------:|


### PR DESCRIPTION
* Unit test `python_major` and `python_minor`

* Also no need to `.strip()` the `mocked_response` JSON, instead deserialise the output string and the expected JSON string into Python objects and compare those