### PR TITLE
Raise if we made a bad request (a 4XX client error or 5XX server error response)

### DIFF
--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -40,8 +40,8 @@ def pypi_stats_api(
 
     r = requests.get(url)
 
-    if r.status_code != 200:
-        return None
+    # Raise if we made a bad request (a 4XX client error or 5XX server error response)
+    r.raise_for_status()
 
     res = r.json()
 


### PR DESCRIPTION
# Before

```console
$ pypistats python_minor pip
None
$ pypistats recent pip
| last_day  | last_month | last_week  |
|----------:|-----------:|-----------:|
| 1,692,600 | 61,864,151 | 14,280,657 |
```

# After

```console
$ pypistats python_minor pip
Traceback (most recent call last):
  File "/usr/local/bin/pypistats", line 11, in <module>
    load_entry_point('pypistats', 'console_scripts', 'pypistats')()
  File "/Users/hugo/github/pypistats/pypistats/cli.py", line 267, in main
    args.func(args)
  File "/Users/hugo/github/pypistats/pypistats/cli.py", line 206, in python_minor
    total=False if args.daily else True,
  File "/Users/hugo/github/pypistats/pypistats/__init__.py", line 255, in python_minor
    return pypi_stats_api(endpoint, params, **kwargs)
  File "/Users/hugo/github/pypistats/pypistats/__init__.py", line 44, in pypi_stats_api
    r.raise_for_status()
  File "/usr/local/lib/python3.7/site-packages/requests/models.py", line 939, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 503 Server Error: SERVICE UNAVAILABLE for url: https://pypistats.org/api/packages/pip/python_minor
$ pypistats recent pip
| last_day  | last_month | last_week  |
|----------:|-----------:|-----------:|
| 1,692,600 | 61,864,151 | 14,280,657 |
```