### PR TITLE
Add --monthly option

### DIFF
--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -100,10 +100,6 @@ def _sort(data):
 def _monthly_total(data):
     """Sum all downloads per category, by month"""
 
-    # Only for lists of dicts, not a single dict
-    if isinstance(data, dict):
-        return data
-
     totalled = {}
     for row in data:
         category = row["category"]

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -29,7 +29,7 @@ def pypi_stats_api(
     start_date=None,
     end_date=None,
     sort=True,
-    total=True,
+    total="all",
 ):
     """Call the API and return JSON"""
     if params:
@@ -48,7 +48,9 @@ def pypi_stats_api(
     if start_date or end_date:
         res["data"] = _filter(res["data"], start_date, end_date)
 
-    if total:
+    if total == "monthly":
+        res["data"] = _monthly_total(res["data"])
+    elif total == "all":
         res["data"] = _total(res["data"])
 
     if format == "json":
@@ -92,6 +94,35 @@ def _sort(data):
         return data
 
     data = sorted(data, key=lambda k: k["downloads"], reverse=True)
+    return data
+
+
+def _monthly_total(data):
+    """Sum all downloads per category, by month"""
+
+    # Only for lists of dicts, not a single dict
+    if isinstance(data, dict):
+        return data
+
+    totalled = {}
+    for row in data:
+        category = row["category"]
+        downloads = row["downloads"]
+        month = row["date"][:7]
+
+        if category in totalled:
+            if month in totalled[category]:
+                totalled[category][month] += downloads
+            else:
+                totalled[category][month] = downloads
+        else:
+            totalled[category] = {month: downloads}
+
+    data = []
+    for category, month_downloads in totalled.items():
+        for month, downloads in month_downloads.items():
+            data.append({"category": category, "date": month, "downloads": downloads})
+
     return data
 
 

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -110,6 +110,7 @@ arg_last_month = argument(
 )
 arg_json = argument("-j", "--json", action="store_true", help='Shortcut for "-f json"')
 arg_daily = argument("-d", "--daily", action="store_true", help="Show daily downloads")
+arg_monthy = argument("--monthly", action="store_true", help="Show monthly downloads")
 arg_format = argument(
     "-f", "--format", default="markdown", choices=FORMATS, help="The format of output"
 )
@@ -138,6 +139,7 @@ def recent(args):  # pragma: no cover
         arg_month,
         arg_last_month,
         arg_daily,
+        arg_monthy,
     ]
 )
 def overall(args):  # pragma: no cover
@@ -151,7 +153,7 @@ def overall(args):  # pragma: no cover
             start_date=args.start_date,
             end_date=args.end_date,
             format=args.format,
-            total=False if args.daily else True,
+            total="daily" if args.daily else ("monthly" if args.monthly else "all"),
         )
     )
 
@@ -167,6 +169,7 @@ def overall(args):  # pragma: no cover
         arg_month,
         arg_last_month,
         arg_daily,
+        arg_monthy,
     ]
 )
 def python_major(args):  # pragma: no cover
@@ -177,7 +180,7 @@ def python_major(args):  # pragma: no cover
             start_date=args.start_date,
             end_date=args.end_date,
             format=args.format,
-            total=False if args.daily else True,
+            total="daily" if args.daily else ("monthly" if args.monthly else "all"),
         )
     )
 
@@ -193,6 +196,7 @@ def python_major(args):  # pragma: no cover
         arg_month,
         arg_last_month,
         arg_daily,
+        arg_monthy,
     ]
 )
 def python_minor(args):  # pragma: no cover
@@ -203,7 +207,7 @@ def python_minor(args):  # pragma: no cover
             start_date=args.start_date,
             end_date=args.end_date,
             format=args.format,
-            total=False if args.daily else True,
+            total="daily" if args.daily else ("monthly" if args.monthly else "all"),
         )
     )
 
@@ -219,6 +223,7 @@ def python_minor(args):  # pragma: no cover
         arg_month,
         arg_last_month,
         arg_daily,
+        arg_monthy,
     ]
 )
 def system(args):  # pragma: no cover
@@ -229,7 +234,7 @@ def system(args):  # pragma: no cover
             start_date=args.start_date,
             end_date=args.end_date,
             format=args.format,
-            total=False if args.daily else True,
+            total="daily" if args.daily else ("monthly" if args.monthly else "all"),
         )
     )
 

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -110,7 +110,7 @@ arg_last_month = argument(
 )
 arg_json = argument("-j", "--json", action="store_true", help='Shortcut for "-f json"')
 arg_daily = argument("-d", "--daily", action="store_true", help="Show daily downloads")
-arg_monthy = argument("--monthly", action="store_true", help="Show monthly downloads")
+arg_monthly = argument("--monthly", action="store_true", help="Show monthly downloads")
 arg_format = argument(
     "-f", "--format", default="markdown", choices=FORMATS, help="The format of output"
 )
@@ -139,7 +139,7 @@ def recent(args):  # pragma: no cover
         arg_month,
         arg_last_month,
         arg_daily,
-        arg_monthy,
+        arg_monthly,
     ]
 )
 def overall(args):  # pragma: no cover
@@ -169,7 +169,7 @@ def overall(args):  # pragma: no cover
         arg_month,
         arg_last_month,
         arg_daily,
-        arg_monthy,
+        arg_monthly,
     ]
 )
 def python_major(args):  # pragma: no cover
@@ -196,7 +196,7 @@ def python_major(args):  # pragma: no cover
         arg_month,
         arg_last_month,
         arg_daily,
-        arg_monthy,
+        arg_monthly,
     ]
 )
 def python_minor(args):  # pragma: no cover
@@ -223,7 +223,7 @@ def python_minor(args):  # pragma: no cover
         arg_month,
         arg_last_month,
         arg_daily,
-        arg_monthy,
+        arg_monthly,
     ]
 )
 def system(args):  # pragma: no cover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+py36 = true

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -315,7 +315,7 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(output, SAMPLE_DATA_RECENT)
 
-    def test_monthly_total(self):
+    def test__monthly_total(self):
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)
 

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -24,8 +24,12 @@ SAMPLE_DATA = [
     {"category": "3.8", "date": "2018-08-15", "downloads": 3},
     {"category": "null", "date": "2018-08-15", "downloads": 1019},
 ]
-SAMPLE_DATA_ONE_ROW = [{"category": "with_mirrors", "downloads": 11497042}]
-SAMPLE_DATA_RECENT = {"last_day": 123002, "last_month": 3254221, "last_week": 761649}
+SAMPLE_DATA_ONE_ROW = [{"category": "with_mirrors", "downloads": 11_497_042}]
+SAMPLE_DATA_RECENT = {
+    "last_day": 123_002,
+    "last_month": 3_254_221,
+    "last_week": 761_649,
+}
 
 
 class TestPypiStats(unittest.TestCase):
@@ -326,7 +330,7 @@ class TestPypiStats(unittest.TestCase):
         self.assertEqual(output[0]["date"], "2018-04")
 
         self.assertEqual(output[10]["category"], "2.7")
-        self.assertEqual(output[10]["downloads"], 489163)
+        self.assertEqual(output[10]["downloads"], 489_163)
         self.assertEqual(output[10]["date"], "2018-05")
 
     def test__total(self):
@@ -362,7 +366,7 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(len(output), original_len + 1)
         self.assertEqual(output[-1]["category"], "Total")
-        self.assertEqual(output[-1]["downloads"], 9355317)
+        self.assertEqual(output[-1]["downloads"], 9_355_317)
 
     def test__grand_total_one_row(self):
         # Arrange

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -311,6 +311,24 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(output, SAMPLE_DATA_RECENT)
 
+    def test_monthly_total(self):
+        # Arrange
+        data = copy.deepcopy(PYTHON_MINOR_DATA)
+
+        # Act
+        output = pypistats._monthly_total(data)
+
+        # Assert
+        self.assertEqual(len(output), 64)
+
+        self.assertEqual(output[0]["category"], "2.4")
+        self.assertEqual(output[0]["downloads"], 1)
+        self.assertEqual(output[0]["date"], "2018-04")
+
+        self.assertEqual(output[10]["category"], "2.7")
+        self.assertEqual(output[10]["downloads"], 489163)
+        self.assertEqual(output[10]["date"], "2018-05")
+
     def test__total(self):
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -620,3 +620,40 @@ class TestPypiStats(unittest.TestCase):
 
         # Assert
         self.assertEqual(output.strip(), expected_output.strip())
+
+    def test_python_minor_monthly(self):
+        # Arrange
+        package = "pip"
+        mocked_url = "https://pypistats.org/api/packages/pip/python_minor"
+        mocked_response = """{
+            "data": [
+                {"category": "2.6", "date": "2018-11-01", "downloads": 1},
+                {"category": "2.6", "date": "2018-11-02", "downloads": 2},
+                {"category": "2.6", "date": "2018-12-11", "downloads": 3},
+                {"category": "2.6", "date": "2018-12-12", "downloads": 4},
+                {"category": "2.7", "date": "2018-11-01", "downloads": 10},
+                {"category": "2.7", "date": "2018-11-02", "downloads": 20},
+                {"category": "2.7", "date": "2018-12-11", "downloads": 30},
+                {"category": "2.7", "date": "2018-12-12", "downloads": 40}
+            ],
+            "package": "pip",
+            "type": "python_minor_downloads"
+        }"""
+        expected_output = """{
+            "data": [
+                {"category": "2.6", "date": "2018-11", "downloads": 3},
+                {"category": "2.6", "date": "2018-12", "downloads": 7},
+                {"category": "2.7", "date": "2018-11", "downloads": 30},
+                {"category": "2.7", "date": "2018-12", "downloads": 70}
+            ],
+            "package": "pip",
+            "type": "python_minor_downloads"
+        }"""
+
+        # Act
+        with requests_mock.Mocker() as m:
+            m.get(mocked_url, text=mocked_response)
+            output = pypistats.python_minor(package, total="monthly", format="json")
+
+        # Assert
+        self.assertEqual(json.loads(output), json.loads(expected_output))


### PR DESCRIPTION
Fixes #36.

Examples:

```console
$ pypistats overall pillow --monthly
|    category     |  date   | percent | downloads  |
|-----------------|---------|--------:|-----------:|
| with_mirrors    | 2018-11 |  11.73% |  4,816,809 |
| without_mirrors | 2018-11 |  11.42% |  4,689,313 |
| with_mirrors    | 2018-10 |  10.01% |  4,111,485 |
| without_mirrors | 2018-10 |   9.63% |  3,954,498 |
| with_mirrors    | 2018-12 |   9.28% |  3,812,114 |
| without_mirrors | 2018-12 |   9.05% |  3,716,624 |
| with_mirrors    | 2018-08 |   8.71% |  3,578,511 |
| without_mirrors | 2018-08 |   8.39% |  3,443,914 |
| with_mirrors    | 2018-09 |   8.20% |  3,367,903 |
| without_mirrors | 2018-09 |   7.90% |  3,242,752 |
| with_mirrors    | 2018-07 |   2.65% |  1,089,350 |
| without_mirrors | 2018-07 |   2.55% |  1,049,092 |
| with_mirrors    | 2018-06 |   0.24% |     97,556 |
| without_mirrors | 2018-06 |   0.23% |     94,061 |
| Total           |         |         | 41,063,982 |

$ pypistats overall pillow --monthly --mirrors false
|    category     |  date   | percent | downloads  |
|-----------------|---------|--------:|-----------:|
| without_mirrors | 2018-11 |  23.23% |  4,689,313 |
| without_mirrors | 2018-10 |  19.59% |  3,954,498 |
| without_mirrors | 2018-12 |  18.41% |  3,716,624 |
| without_mirrors | 2018-08 |  17.06% |  3,443,914 |
| without_mirrors | 2018-09 |  16.06% |  3,242,752 |
| without_mirrors | 2018-07 |   5.20% |  1,049,092 |
| without_mirrors | 2018-06 |   0.47% |     94,061 |
| Total           |         |         | 20,190,254 |

$ pypistats python_major pillow --monthly
| category |  date   | percent | downloads  |
|----------|---------|--------:|-----------:|
|        3 | 2018-11 |  12.72% |  2,567,516 |
|        3 | 2018-10 |  10.95% |  2,211,173 |
|        3 | 2018-12 |  10.37% |  2,093,491 |
|        2 | 2018-11 |  10.31% |  2,081,560 |
|        3 | 2018-08 |   9.02% |  1,821,099 |
|        2 | 2018-10 |   8.47% |  1,709,751 |
|        3 | 2018-09 |   8.43% |  1,701,355 |
|        2 | 2018-12 |   7.91% |  1,597,639 |
|        2 | 2018-08 |   7.91% |  1,596,562 |
|        2 | 2018-09 |   7.50% |  1,514,017 |
|        3 | 2018-07 |   2.76% |    558,222 |
|        2 | 2018-07 |   2.39% |    482,908 |
|        3 | 2018-06 |   0.26% |     53,421 |
| null     | 2018-11 |   0.20% |     40,237 |
|        2 | 2018-06 |   0.20% |     40,027 |
| null     | 2018-10 |   0.17% |     33,574 |
| null     | 2018-09 |   0.14% |     27,380 |
| null     | 2018-08 |   0.13% |     26,253 |
| null     | 2018-12 |   0.13% |     25,494 |
| null     | 2018-07 |   0.04% |      7,962 |
| null     | 2018-06 |   0.00% |        613 |
| Total    |         |         | 20,190,254 |

$ pypistats system pillow --monthly
| category |  date   | percent | downloads  |
|----------|---------|--------:|-----------:|
| Linux    | 2018-11 |  20.06% |  4,051,149 |
| Linux    | 2018-10 |  16.48% |  3,327,387 |
| Linux    | 2018-12 |  16.03% |  3,235,530 |
| Linux    | 2018-08 |  14.46% |  2,918,631 |
| Linux    | 2018-09 |  13.64% |  2,753,812 |
| Linux    | 2018-07 |   4.32% |    871,471 |
| Windows  | 2018-11 |   1.90% |    383,404 |
| Windows  | 2018-10 |   1.77% |    357,659 |
| Windows  | 2018-08 |   1.54% |    311,885 |
| Windows  | 2018-12 |   1.47% |    297,117 |
| Windows  | 2018-09 |   1.43% |    288,276 |
| Darwin   | 2018-10 |   0.93% |    187,771 |
| Darwin   | 2018-11 |   0.83% |    167,798 |
| Darwin   | 2018-08 |   0.70% |    140,773 |
| Darwin   | 2018-09 |   0.63% |    127,686 |
| Darwin   | 2018-12 |   0.60% |    122,087 |
| Windows  | 2018-07 |   0.52% |    104,781 |
| null     | 2018-11 |   0.42% |     84,852 |
| Linux    | 2018-06 |   0.39% |     79,716 |
| null     | 2018-10 |   0.39% |     79,369 |
| null     | 2018-09 |   0.35% |     71,430 |
| null     | 2018-08 |   0.35% |     71,003 |
| null     | 2018-12 |   0.30% |     60,339 |
| Darwin   | 2018-07 |   0.25% |     50,158 |
| null     | 2018-07 |   0.11% |     22,037 |
| Windows  | 2018-06 |   0.04% |      8,257 |
| Darwin   | 2018-06 |   0.02% |      3,918 |
| other    | 2018-10 |   0.01% |      2,312 |
| null     | 2018-06 |   0.01% |      2,119 |
| other    | 2018-11 |   0.01% |      2,110 |
| other    | 2018-08 |   0.01% |      1,622 |
| other    | 2018-12 |   0.01% |      1,551 |
| other    | 2018-09 |   0.01% |      1,548 |
| other    | 2018-07 |   0.00% |        645 |
| other    | 2018-06 |   0.00% |         51 |
| Total    |         |         | 20,190,254 |

```

