### PR TITLE
Add local caching of API calls

### DIFF
--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -7,6 +7,7 @@ https://pypistats.org/api
 import json
 from datetime import datetime
 from pathlib import Path
+import atexit
 
 import requests
 from appdirs import user_cache_dir
@@ -61,7 +62,16 @@ def _save_cache(cache_file, data):
         pass
 
 
-# TODO delete old cache files, do as very last task
+def _clear_cache():
+    """Delete old cache files, run as last task"""
+    cache_files = CACHE_DIR.glob("**/*.json")
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    for cache_file in cache_files:
+        if not cache_file.name.startswith(today):
+            cache_file.unlink()
+
+
+atexit.register(_clear_cache)
 
 
 def pypi_stats_api(

--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -65,9 +65,9 @@ def _save_cache(cache_file, data):
 def _clear_cache():
     """Delete old cache files, run as last task"""
     cache_files = CACHE_DIR.glob("**/*.json")
-    today = datetime.utcnow().strftime("%Y-%m-%d")
+    this_month = datetime.utcnow().strftime("%Y-%m")
     for cache_file in cache_files:
-        if not cache_file.name.startswith(today):
+        if not cache_file.name.startswith(this_month):
             cache_file.unlink()
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,13 @@ setup(
     packages=find_packages(),
     entry_points={"console_scripts": ["pypistats = pypistats.cli:main"]},
     zip_safe=True,
-    install_requires=["pytablewriter>=0.33.0", "python-dateutil", "requests"],
+    install_requires=[
+        "appdirs",
+        "pytablewriter>=0.33.0",
+        "python-dateutil",
+        "python-slugify",
+        "requests",
+    ],
     tests_require=[
         "black",
         "flake8",

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -10,6 +10,7 @@ import unittest
 import requests_mock
 
 import pypistats
+
 from .data.python_minor import DATA as PYTHON_MINOR_DATA
 
 SAMPLE_DATA = [
@@ -28,7 +29,20 @@ SAMPLE_DATA_ONE_ROW = [{"category": "with_mirrors", "downloads": 11497042}]
 SAMPLE_DATA_RECENT = {"last_day": 123002, "last_month": 3254221, "last_week": 761649}
 
 
+def stub_save_cache(cache_file, data):
+    pass
+
+
 class TestPypiStats(unittest.TestCase):
+    def setUp(self):
+        # Stub caching. Caches are tested in another class.
+        self.original_save_cache = pypistats._save_cache
+        pypistats._save_cache = stub_save_cache
+
+    def tearDown(self):
+        # Unstub caching
+        pypistats._save_cache = self.original_save_cache
+
     def test__filter_no_filters_no_change(self):
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)

--- a/tests/test_pypistats_cache.py
+++ b/tests/test_pypistats_cache.py
@@ -78,7 +78,7 @@ class TestPypiStatsCache(unittest.TestCase):
     def test__clear_cache(self):
         # Arrange
         # Create old cache file
-        cache_file = pypistats.CACHE_DIR / "2018-12-26-old-cache-file.json"
+        cache_file = pypistats.CACHE_DIR / "2018-11-26-old-cache-file.json"
         pypistats._save_cache(cache_file, data={})
         self.assertTrue(cache_file.exists())
 

--- a/tests/test_pypistats_cache.py
+++ b/tests/test_pypistats_cache.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+"""
+Unit tests for pypistats cache
+"""
+import tempfile
+import unittest
+from pathlib import Path
+
+from freezegun import freeze_time
+
+import pypistats
+
+
+class TestPypiStatsCache(unittest.TestCase):
+    def setUp(self):
+        # Choose a new cache dir that doesn't exist
+        self.original_cache_dir = pypistats.CACHE_DIR
+        self.temp_dir = tempfile.TemporaryDirectory()
+        pypistats.CACHE_DIR = Path(self.temp_dir.name) / "pypistats"
+
+    def tearDown(self):
+        # Reset original
+        pypistats.CACHE_DIR = self.original_cache_dir
+
+    @freeze_time("2018-12-26")
+    def test__cache_filename(self):
+        # Arrange
+        url = "https://pypistats.org/api/packages/pip/recent"
+
+        # Act
+        out = pypistats._cache_filename(url)
+
+        # Assert
+        self.assertTrue(
+            str(out).endswith(
+                "2018-12-26-https-pypistats-org-api-packages-pip-recent.json"
+            )
+        )
+
+    def test__load_cache_not_exist(self):
+        # Arrange
+        filename = Path("file-does-not-exist")
+
+        # Act
+        data = pypistats._load_cache(filename)
+
+        # Assert
+        self.assertEqual(data, {})
+
+    def test__load_cache_bad_data(self):
+        # Arrange
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(b"Invalid JSON!")
+
+            # Act
+            data = pypistats._load_cache(Path(f.name))
+
+        # Assert
+        self.assertEqual(data, {})
+
+    def test_cache_round_trip(self):
+        # Arrange
+        filename = pypistats.CACHE_DIR / "test_cache_round_trip.json"
+        data = "test data"
+
+        # Act
+        pypistats._save_cache(filename, data)
+        new_data = pypistats._load_cache(filename)
+
+        # Tidy up
+        filename.unlink()
+
+        # Assert
+        self.assertEqual(new_data, data)

--- a/tests/test_pypistats_cache.py
+++ b/tests/test_pypistats_cache.py
@@ -73,3 +73,16 @@ class TestPypiStatsCache(unittest.TestCase):
 
         # Assert
         self.assertEqual(new_data, data)
+
+    def test__clear_cache(self):
+        # Arrange
+        # Create old cache file
+        cache_file = pypistats.CACHE_DIR / "2018-12-26-old-cache-file.json"
+        pypistats._save_cache(cache_file, data={})
+        self.assertTrue(cache_file.exists())
+
+        # Act
+        pypistats._clear_cache()
+
+        # Assert
+        self.assertFalse(cache_file.exists())


### PR DESCRIPTION
Each remote API call returns quite a big chunk of JSON. Quite a few of this tool's options filter that JSON data locally, like the date ranges and output formats.

This PR caches the JSON locally, to substantially speed up runs and reduce load on the remote server, especially for subsequent commands on different date ranges.

Data is saved as JSON files beginning with the current UTC `yyyy-mm-dd` and then with a slugified version of the API endpoint called.

For example, in `/Users/hugo/Library/Caches/pypistats/`:

* `2018-12-27-https-pypistats-org-api-packages-pillow-overall.json`
* `2018-12-27-https-pypistats-org-api-packages-pillow-python-minor.json`
* `2018-12-27-https-pypistats-org-api-packages-wandb-python-minor.json`

The remote server will likely return different data the next day, so a new cache file will be created. Old cache files are deleted at exit, those older than the current month.
