### PR TITLE
Fix ValueError: month must be in 1..12

### DIFF
--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -243,7 +243,7 @@ def _month(yyyy_mm):
     """Helper to return start_date and end_date of a month as yyyy-mm-dd"""
     year, month = map(int, yyyy_mm.split("-"))
     first = date(year, month, 1)
-    last = date(year, month + 1, 1) - relativedelta(days=1)
+    last = first + relativedelta(months=1) - relativedelta(days=1)
     return str(first), str(last)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,17 @@ class TestCli(unittest.TestCase):
         self.assertEqual(first, "2018-07-01")
         self.assertEqual(last, "2018-07-31")
 
+    def test__month_12(self):
+        # Arrange
+        yyyy_mm = "2018-12"
+
+        # Act
+        first, last = cli._month(yyyy_mm)
+
+        # Assert
+        self.assertEqual(first, "2018-12-01")
+        self.assertEqual(last, "2018-12-31")
+
     @freeze_time("2018-09-25")
     def test__last_month(self):
         # Arrange


### PR DESCRIPTION
Fixes #40.

Don't add 1 to the month number. If it's December, that gives month 13, causing `ValueError: month must be in 1..12`.

Instead add `relativedelta(months=1)`.
