### PR TITLE
Refactor: Use writer.style_list instead of align_list and format_list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
   include:
     - python: 3.7
       dist: xenial
-      sudo: required
     - python: 3.6
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     zip_safe=True,
     install_requires=[
         "appdirs",
-        "pytablewriter>=0.33.0",
+        "pytablewriter>=0.37.0",
         "python-dateutil",
         "python-slugify",
         "requests",

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -443,21 +443,6 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(output, SAMPLE_DATA_RECENT)
 
-    def test__custom_list(self):
-        # Arrange
-        input_list = [1, 2, 3, 4]
-        special_item = 3
-        default_value = 0
-        special_value = 100
-
-        # Act
-        output = pypistats._custom_list(
-            input_list, special_item, default_value, special_value
-        )
-
-        # Assert
-        self.assertEqual(output, [0, 0, 100, 0])
-
     def test_valid_json(self):
         # Arrange
         package = "pip"


### PR DESCRIPTION
https://github.com/thombashi/pytablewriter/issues/4#issuecomment-450871213:

> I integrated `format_list` attribute into `style_list` attribute at `pytablewriter 0.37.0`.
> `format_list` can still be used (may be removed in the future release).
> 
> [pytablewriter.readthedocs.io/en/latest/pages/examples/style/index.html](https://pytablewriter.readthedocs.io/en/latest/pages/examples/style/index.html)

