### PR TITLE
Add -v --verbose, use capped -V for version

### DIFF
--- a/pypistats/__init__.py
+++ b/pypistats/__init__.py
@@ -6,6 +6,7 @@ https://pypistats.org/api
 """
 import atexit
 import json
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -21,6 +22,17 @@ __version__ = version.__version__
 
 BASE_URL = "https://pypistats.org/api/"
 CACHE_DIR = Path(user_cache_dir("pypistats"))
+
+
+def _print_verbose(verbose, *args, **kwargs):
+    """Print if verbose"""
+    if verbose:
+        _print_stderr(*args, **kwargs)
+
+
+def _print_stderr(*args, **kwargs):
+    """Print to stderr"""
+    print(*args, file=sys.stderr, **kwargs)
 
 
 def _cache_filename(url):
@@ -77,6 +89,7 @@ def pypi_stats_api(
     end_date=None,
     sort=True,
     total="all",
+    verbose=False,
 ):
     """Call the API and return JSON"""
     if params:
@@ -85,9 +98,12 @@ def pypi_stats_api(
         params = ""
     url = BASE_URL + endpoint.lower() + params
     cache_file = _cache_filename(url)
+    _print_verbose(verbose, "API URL:", url)
+    _print_verbose(verbose, "Cache file:", cache_file)
 
     res = {}
     if cache_file.is_file():
+        _print_verbose(verbose, "Cache file exists")
         res = _load_cache(cache_file)
 
     if res == {}:
@@ -96,6 +112,7 @@ def pypi_stats_api(
 
         # Raise if we made a bad request
         # (4XX client error or 5XX server error response)
+        _print_verbose(verbose, "HTTP status code:", r.status_code)
         r.raise_for_status()
 
         res = r.json()

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -114,6 +114,9 @@ arg_monthly = argument("--monthly", action="store_true", help="Show monthly down
 arg_format = argument(
     "-f", "--format", default="markdown", choices=FORMATS, help="The format of output"
 )
+arg_verbose = argument(
+    "-v", "--verbose", action="store_true", help="Print debug messages to stderr"
+)
 
 
 @subcommand(
@@ -122,10 +125,15 @@ arg_format = argument(
         argument("-p", "--period", choices=("day", "week", "month")),
         arg_format,
         arg_json,
+        arg_verbose,
     ]
 )
 def recent(args):  # pragma: no cover
-    print(pypistats.recent(args.package, period=args.period, format=args.format))
+    print(
+        pypistats.recent(
+            args.package, period=args.period, format=args.format, verbose=args.verbose
+        )
+    )
 
 
 @subcommand(
@@ -140,6 +148,7 @@ def recent(args):  # pragma: no cover
         arg_last_month,
         arg_daily,
         arg_monthly,
+        arg_verbose,
     ]
 )
 def overall(args):  # pragma: no cover
@@ -154,6 +163,7 @@ def overall(args):  # pragma: no cover
             end_date=args.end_date,
             format=args.format,
             total="daily" if args.daily else ("monthly" if args.monthly else "all"),
+            verbose=args.verbose,
         )
     )
 
@@ -161,7 +171,7 @@ def overall(args):  # pragma: no cover
 @subcommand(
     [
         argument("package"),
-        argument("-v", "--version", help="eg. 2 or 3"),
+        argument("-V", "--version", help="eg. 2 or 3"),
         arg_format,
         arg_json,
         arg_start_date,
@@ -170,6 +180,7 @@ def overall(args):  # pragma: no cover
         arg_last_month,
         arg_daily,
         arg_monthly,
+        arg_verbose,
     ]
 )
 def python_major(args):  # pragma: no cover
@@ -181,6 +192,7 @@ def python_major(args):  # pragma: no cover
             end_date=args.end_date,
             format=args.format,
             total="daily" if args.daily else ("monthly" if args.monthly else "all"),
+            verbose=args.verbose,
         )
     )
 
@@ -188,7 +200,7 @@ def python_major(args):  # pragma: no cover
 @subcommand(
     [
         argument("package"),
-        argument("-v", "--version", help="eg. 2.7 or 3.6"),
+        argument("-V", "--version", help="eg. 2.7 or 3.6"),
         arg_format,
         arg_json,
         arg_start_date,
@@ -197,6 +209,7 @@ def python_major(args):  # pragma: no cover
         arg_last_month,
         arg_daily,
         arg_monthly,
+        arg_verbose,
     ]
 )
 def python_minor(args):  # pragma: no cover
@@ -208,6 +221,7 @@ def python_minor(args):  # pragma: no cover
             end_date=args.end_date,
             format=args.format,
             total="daily" if args.daily else ("monthly" if args.monthly else "all"),
+            verbose=args.verbose,
         )
     )
 
@@ -224,6 +238,7 @@ def python_minor(args):  # pragma: no cover
         arg_last_month,
         arg_daily,
         arg_monthly,
+        arg_verbose,
     ]
 )
 def system(args):  # pragma: no cover
@@ -235,6 +250,7 @@ def system(args):  # pragma: no cover
             end_date=args.end_date,
             format=args.format,
             total="daily" if args.daily else ("monthly" if args.monthly else "all"),
+            verbose=args.verbose,
         )
     )
 
@@ -256,7 +272,7 @@ def _last_month():
 
 def main():
     cli.add_argument(
-        "-v", "--version", action="version", version=f"%(prog)s {pypistats.__version__}"
+        "-V", "--version", action="version", version=f"%(prog)s {pypistats.__version__}"
     )
     args = cli.parse_args()
     if args.subcommand is None:

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -656,3 +656,16 @@ class TestPypiStats(unittest.TestCase):
 
         # Assert
         self.assertEqual(json.loads(output), json.loads(expected_output))
+
+
+# pytest's capsys cannot be used in a unittest class
+def test__print_verbose_print(capsys):
+    # Arrange
+    verbose = True
+
+    # Act
+    pypistats._print_verbose(verbose, "test output")
+
+    # Assert
+    captured = capsys.readouterr()
+    assert captured.err == "test output\n"


### PR DESCRIPTION
Add `-v --verbose` argument to show some debug info.

Uppercase version's `-v` to `-V` to avoid conflict.