### PR TITLE
Optional days: --start-date and --end-date can yyyy-mm-dd or yyyy-mm

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ optional arguments:
                         The format of output (default: markdown)
   -j, --json            Shortcut for "-f json" (default: False)
   -v, --verbose         Print debug messages to stderr (default: False)
-  ```
+```
 
 Get recent downloads:
 
@@ -82,7 +82,7 @@ Help for another subcommand:
 ```console
 $ pypistats python_minor --help
 usage: pypistats python_minor [-h] [-V VERSION] [-f {json,markdown,rst,html}]
-                              [-j] [-sd yyyy-mm-dd] [-ed yyyy-mm-dd]
+                              [-j] [-sd yyyy-mm[-dd]] [-ed yyyy-mm[-dd]]
                               [-m yyyy-mm] [-l] [-d] [--monthly] [-v]
                               package
 
@@ -99,9 +99,9 @@ optional arguments:
   -f {json,markdown,rst,html}, --format {json,markdown,rst,html}
                         The format of output (default: markdown)
   -j, --json            Shortcut for "-f json" (default: False)
-  -sd yyyy-mm-dd, --start-date yyyy-mm-dd
+  -sd yyyy-mm[-dd], --start-date yyyy-mm[-dd]
                         Start date (default: None)
-  -ed yyyy-mm-dd, --end-date yyyy-mm-dd
+  -ed yyyy-mm[-dd], --end-date yyyy-mm[-dd]
                         End date (default: None)
   -m yyyy-mm, --month yyyy-mm
                         Shortcut for -sd & -ed for a single month (default:

--- a/pypistats/cli.py
+++ b/pypistats/cli.py
@@ -76,6 +76,13 @@ def _valid_yyyy_mm(date_string):
     return _valid_date(date_string, "%Y-%m")
 
 
+def _valid_yyyy_mm_optional_dd(date_string):
+    try:
+        return _valid_yyyy_mm_dd(date_string)
+    except argparse.ArgumentTypeError:
+        return _valid_yyyy_mm(date_string)
+
+
 def _define_format(args) -> str:
     if args.json:
         return "json"
@@ -88,12 +95,16 @@ FORMATS = ("json", "markdown", "rst", "html")
 arg_start_date = argument(
     "-sd",
     "--start-date",
-    metavar="yyyy-mm-dd",
-    type=_valid_yyyy_mm_dd,
+    metavar="yyyy-mm[-dd]",
+    type=_valid_yyyy_mm_optional_dd,
     help="Start date",
 )
 arg_end_date = argument(
-    "-ed", "--end-date", metavar="yyyy-mm-dd", type=_valid_yyyy_mm_dd, help="End date"
+    "-ed",
+    "--end-date",
+    metavar="yyyy-mm[-dd]",
+    type=_valid_yyyy_mm_optional_dd,
+    help="End date",
 )
 arg_month = argument(
     "-m",
@@ -278,6 +289,25 @@ def main():
     if args.subcommand is None:
         cli.print_help()
     else:
+
+        # Convert yyyy-mm to yyyy-mm-dd
+        if hasattr(args, "start_date") and args.start_date:
+            try:
+                # yyyy-mm
+                args.start_date, _ = _month(args.start_date)
+            except ValueError:
+                # yyyy-mm-dd
+                pass
+
+        # Convert yyyy-mm to yyyy-mm-dd
+        if hasattr(args, "end_date") and args.end_date:
+            try:
+                # yyyy-mm
+                _, args.end_date = _month(args.end_date)
+            except ValueError:
+                # yyyy-mm-dd
+                pass
+
         if hasattr(args, "month") and args.month:
             args.start_date, args.end_date = _month(args.month)
         if hasattr(args, "last_month") and args.last_month:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,6 +101,34 @@ class TestCli(unittest.TestCase):
         with self.assertRaises(argparse.ArgumentTypeError):
             cli._valid_yyyy_mm(input)
 
+    def test__valid_yyyy_mm_optional_dd1(self):
+        # Arrange
+        input = "2019-01-21"
+
+        # Act
+        output = cli._valid_yyyy_mm_optional_dd(input)
+
+        # Assert
+        self.assertEqual(input, output)
+
+    def test__valid_yyyy_mm_optional_dd2(self):
+        # Arrange
+        input = "2019-01"
+
+        # Act
+        output = cli._valid_yyyy_mm_optional_dd(input)
+
+        # Assert
+        self.assertEqual(input, output)
+
+    def test__valid_yyyy_mm_optional_dd_invalid(self):
+        # Arrange
+        input = "dkvnf"
+
+        # Act / Assert
+        with self.assertRaises(argparse.ArgumentTypeError):
+            cli._valid_yyyy_mm_dd(input)
+
     def test__define_format_default(self):
         # Setup
         args = self.__Args()


### PR DESCRIPTION
If the `-dd` is omitted, `--start-date` is the first of the month and `--end-date` is the last of the month.

These are equivalent:
```
pypistats python_minor pillow --start-date 2018-11 --end-date 2018-12
pypistats python_minor pillow --start-date 2018-11 --end-date 2018-12-31
pypistats python_minor pillow --start-date 2018-11-01 --end-date 2018-12
pypistats python_minor pillow --start-date 2018-11-01 --end-date 2018-12-31
```

And all output:

| category | percent | downloads |
|----------|--------:|----------:|
|      2.7 |  43.77% | 3,956,272 |
|      3.6 |  32.98% | 2,980,367 |
|      3.5 |  11.32% | 1,023,441 |
|      3.7 |   7.48% |   675,924 |
|      3.4 |   3.58% |   323,657 |
| null     |   0.77% |    69,249 |
|      3.3 |   0.06% |     5,049 |
|      2.6 |   0.03% |     2,532 |
|      3.8 |   0.01% |     1,143 |
|      3.2 |   0.00% |       119 |
|      2.4 |   0.00% |        17 |
| Total    |         | 9,037,770 |
