### PR TITLE
Azure Pipelines: Trigger a build for every branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,9 +3,6 @@
 # Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
-trigger:
-- master
-
 jobs:
 
 - template: .azure-pipelines/jobs/lint.yml


### PR DESCRIPTION
> A trigger specifies what branches will cause a continuous integration build to run. If left unspecified, pushes to every branch will trigger a build.

https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azdevops&tabs=schema#trigger