### PR TITLE
Also track coverage inside Azure Pipelines

### DIFF
--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -38,7 +38,7 @@ jobs:
 
   - script: |
       python -m pip install --upgrade codecov
-      codecov --name "Azure: Python $(python.version)" --build $(Build.BuildNumber) --token $(CODECOV_TOKEN)
+      codecov --name "Azure: ${{ parameters.name }} Python $(python.version)" --build $(Build.BuildNumber) --token $(CODECOV_TOKEN)
     condition: succeeded()
     displayName: 'Upload to Codecov'
 

--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -28,7 +28,7 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      pytest --cov pypistats --junitxml=junit/test-results.xml --cov-report xml
+      pytest --cov pypistats --junitxml=junit/test-results.xml --cov-report html --cov-report xml
     displayName: 'Unit tests'
 
   - script: |
@@ -47,6 +47,7 @@ jobs:
     inputs:
       codeCoverageTool: cobertura
       summaryFileLocation: coverage.xml
+      reportDirectory: '**/htmlcov'
 
   - task: PublishTestResults@2
     inputs:

--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -39,8 +39,15 @@ jobs:
   - script: |
       python -m pip install --upgrade codecov
       codecov --name "Python $(python.version)" --build $(Build.BuildNumber) --token $(CODECOV_TOKEN)
+      coverage xml -o coverage.xml # For PublishCodeCoverageResults
     condition: succeeded()
     displayName: 'Upload to Codecov'
+
+  - task: PublishCodeCoverageResults@1
+    condition: succeeded()
+    inputs:
+      codeCoverageTool: cobertura
+      summaryFileLocation: coverage.xml
 
   - task: PublishTestResults@2
     inputs:

--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -28,7 +28,7 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      pytest --cov pypistats --cov-report html
+      pytest --cov pypistats --cov-report html --test-run-title="${{ parameters.name }} Python $(python.version)"
     displayName: 'Unit tests'
 
   - script: |

--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -28,7 +28,7 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      pytest --cov pypistats --junitxml=junit/test-results.xml
+      pytest --cov pypistats --junitxml=junit/test-results.xml --cov-report xml
     displayName: 'Unit tests'
 
   - script: |
@@ -39,7 +39,6 @@ jobs:
   - script: |
       python -m pip install --upgrade codecov
       codecov --name "Python $(python.version)" --build $(Build.BuildNumber) --token $(CODECOV_TOKEN)
-      coverage xml -o coverage.xml # For PublishCodeCoverageResults
     condition: succeeded()
     displayName: 'Upload to Codecov'
 

--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -38,7 +38,7 @@ jobs:
 
   - script: |
       python -m pip install --upgrade codecov
-      codecov --name "Python $(python.version)" --build $(Build.BuildNumber) --token $(CODECOV_TOKEN)
+      codecov --name "Azure: Python $(python.version)" --build $(Build.BuildNumber) --token $(CODECOV_TOKEN)
     condition: succeeded()
     displayName: 'Upload to Codecov'
 

--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -23,12 +23,12 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
-      python -m pip install --upgrade freezegun pytest pytest-cov requests_mock
+      python -m pip install --upgrade freezegun pytest pytest-azurepipelines pytest-cov requests_mock
       python -m pip install  -e .
     displayName: 'Install dependencies'
 
   - script: |
-      pytest --cov pypistats --junitxml=junit/test-results.xml --cov-report html --cov-report xml
+      pytest --cov pypistats --cov-report html
     displayName: 'Unit tests'
 
   - script: |
@@ -41,16 +41,3 @@ jobs:
       codecov --name "Azure: ${{ parameters.name }} Python $(python.version)" --build $(Build.BuildNumber) --token $(CODECOV_TOKEN)
     condition: succeeded()
     displayName: 'Upload to Codecov'
-
-  - task: PublishCodeCoverageResults@1
-    condition: succeeded()
-    inputs:
-      codeCoverageTool: cobertura
-      summaryFileLocation: coverage.xml
-      reportDirectory: '**/htmlcov'
-
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: '**/test-results.xml'
-      testRunTitle: 'Python $(python.version)'
-    condition: succeededOrFailed()


### PR DESCRIPTION
Looks like it needs both `coverage.xml` and HTML files in `htmlcov/`

The output is a bit ugly:

* https://dev.azure.com/hugovk/hugovk/_build/results?buildId=102&view=codecoverage-tab

Much nicer reports at Codecov:

* https://codecov.io/gh/hugovk/pypistats

Which include both Azure and Travis builds:

* https://codecov.io/gh/hugovk/pypistats/commit/e3929a9a63e3e9497ea5f7950800aa66337cde27/build


Also label the Azure builds on Codecov more clearly. 

* For example, "Python 3.6" -> "Azure: macOS Python 3.6"
