### PR TITLE
Allow month names as parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ Help for another subcommand:
 ```console
 $ pypistats python_minor --help
 usage: pypistats python_minor [-h] [-V VERSION] [-f {json,markdown,rst,html}]
-                              [-j] [-sd yyyy-mm[-dd]] [-ed yyyy-mm[-dd]]
-                              [-m yyyy-mm] [-l] [-t] [-d] [--monthly] [-v]
+                              [-j] [-sd yyyy-mm[-dd]|name]
+                              [-ed yyyy-mm[-dd]|name] [-m yyyy-mm|name] [-l]
+                              [-t] [-d] [--monthly] [-v]
                               package
 
 Retrieve the aggregate daily download time series by Python minor version
@@ -100,11 +101,11 @@ optional arguments:
   -f {json,markdown,rst,html}, --format {json,markdown,rst,html}
                         The format of output (default: markdown)
   -j, --json            Shortcut for "-f json" (default: False)
-  -sd yyyy-mm[-dd], --start-date yyyy-mm[-dd]
+  -sd yyyy-mm[-dd]|name, --start-date yyyy-mm[-dd]|name
                         Start date (default: None)
-  -ed yyyy-mm[-dd], --end-date yyyy-mm[-dd]
+  -ed yyyy-mm[-dd]|name, --end-date yyyy-mm[-dd]|name
                         End date (default: None)
-  -m yyyy-mm, --month yyyy-mm
+  -m yyyy-mm|name, --month yyyy-mm|name
                         Shortcut for -sd & -ed for a single month (default:
                         None)
   -l, --last-month      Shortcut for -sd & -ed for last month (default: False)
@@ -151,6 +152,22 @@ The table is Markdown, ready for pasting in GitHub issues and PRs:
 |      2.4 |   0.00% |         7 |
 | Total    |         | 3,242,752 |
 
+These are equivalent (in May 2019):
+
+```sh
+pypistats python_major pip --last-month
+pypistats python_major pip --month april
+pypistats python_major pip --month apr
+pypistats python_major pip --month 2019-04
+```
+
+And:
+
+```sh
+pypistats python_major pip --start-date december --end-date january
+pypistats python_major pip --start-date dec      --end-date jan
+pypistats python_major pip --start-date 2018-12  --end-date 2019-01
+```
 
 ## Example programmatic use
 

--- a/src/pypistats/cli.py
+++ b/src/pypistats/cli.py
@@ -118,14 +118,14 @@ FORMATS = ("json", "markdown", "rst", "html")
 arg_start_date = argument(
     "-sd",
     "--start-date",
-    metavar="yyyy-mm[-dd]",
+    metavar="yyyy-mm[-dd]|name",
     type=_valid_yyyy_mm_optional_dd,
     help="Start date",
 )
 arg_end_date = argument(
     "-ed",
     "--end-date",
-    metavar="yyyy-mm[-dd]",
+    metavar="yyyy-mm[-dd]|name",
     type=_valid_yyyy_mm_optional_dd,
     help="End date",
 )

--- a/src/pypistats/cli.py
+++ b/src/pypistats/cli.py
@@ -59,6 +59,17 @@ def subcommand(args=None, parent=subparsers):
     return decorator
 
 
+def _month_name_to_yyyy_mm(date_string, date_format):
+    """Given a month name, return yyyy-dd for the most recent month in the past"""
+    today = date.today()
+    new = datetime.strptime(f"{date_string} {today.year}", f"{date_format} %Y").date()
+    if new < today:
+        return new.isoformat()[:7]
+
+    new = datetime.strptime(f"{date_string} {today.year-1}", f"{date_format} %Y").date()
+    return new.isoformat()[:7]
+
+
 def _valid_date(date_string, date_format):
     try:
         datetime.strptime(date_string, date_format)
@@ -73,6 +84,18 @@ def _valid_yyyy_mm_dd(date_string):
 
 
 def _valid_yyyy_mm(date_string):
+    try:
+        # eg. jan, feb
+        date_string = _month_name_to_yyyy_mm(date_string, "%b")
+    except ValueError:
+        pass
+
+    try:
+        # eg. january, february
+        date_string = _month_name_to_yyyy_mm(date_string, "%B")
+    except ValueError:
+        pass
+
     return _valid_date(date_string, "%Y-%m")
 
 
@@ -109,7 +132,7 @@ arg_end_date = argument(
 arg_month = argument(
     "-m",
     "--month",
-    metavar="yyyy-mm",
+    metavar="yyyy-mm|name",
     type=_valid_yyyy_mm,
     help="Shortcut for -sd & -ed for a single month",
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,6 +129,14 @@ def test__valid_yyyy_mm_optional_dd_valid(test_input):
     assert test_input == cli._valid_yyyy_mm_optional_dd(test_input)
 
 
+@freeze_time("2019-05-08")
+@pytest.mark.parametrize(
+    "test_input, expected", [("jan", "2019-01"), ("february", "2019-02")]
+)
+def test__valid_yyyy_mm_optional_dd_valid_name(test_input, expected):
+    assert expected == cli._valid_yyyy_mm_optional_dd(test_input)
+
+
 @pytest.mark.parametrize("test_input", ["dkvnf", "2018-99", "2018-xx"])
 def test__valid_yyyy_mm_optional_dd_invalid(test_input):
     with pytest.raises(argparse.ArgumentTypeError):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,7 +85,7 @@ def test__month_name_to_yyyy_mm(name, date_format, expected):
 
 
 @pytest.mark.parametrize("test_input", ["2018-01-12", "2018-07-12", "2018-12-12"])
-def test__valid_yyyy_mm_dd(test_input):
+def test__valid_yyyy_mm_dd_valid(test_input):
     assert test_input == cli._valid_yyyy_mm_dd(test_input)
 
 
@@ -93,6 +93,17 @@ def test__valid_yyyy_mm_dd(test_input):
 def test__valid_yyyy_mm_dd_invalid(test_input):
     with pytest.raises(argparse.ArgumentTypeError):
         cli._valid_yyyy_mm_dd(test_input)
+
+
+@pytest.mark.parametrize("test_input", ["2018-01", "2018-07", "2018-12"])
+def test__valid_yyyy_mm_valid(test_input):
+    assert test_input == cli._valid_yyyy_mm(test_input)
+
+
+@pytest.mark.parametrize("test_input", ["dfkgjskfjgk", "2018-99", "2018-xx"])
+def test__valid_yyyy_mm_invalid(test_input):
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli._valid_yyyy_mm(test_input)
 
 
 @freeze_time("2019-05-08")
@@ -119,32 +130,6 @@ class TestCli(unittest.TestCase):
         def __init__(self):
             self.json = False  # type: bool
             self.format = "markdown"  # type: str
-
-    def test__valid_yyyy_mm(self):
-        # Arrange
-        input = "2018-07"
-
-        # Act
-        output = cli._valid_yyyy_mm(input)
-
-        # Assert
-        self.assertEqual(input, output)
-
-    def test__valid_yyyy_mm_invalid(self):
-        # Arrange
-        input = "dfkgjskfjgk"
-
-        # Act / Assert
-        with self.assertRaises(argparse.ArgumentTypeError):
-            cli._valid_yyyy_mm(input)
-
-    def test__valid_yyyy_mm_invalid2(self):
-        # Arrange
-        input = "2018-99"
-
-        # Act / Assert
-        with self.assertRaises(argparse.ArgumentTypeError):
-            cli._valid_yyyy_mm(input)
 
     def test__valid_yyyy_mm_optional_dd1(self):
         # Arrange

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,22 @@ def test__month(yyyy_mm, expected):
     assert expected == (first, last)
 
 
+@pytest.mark.parametrize(
+    "yyyy_mm_dd, expected",
+    [
+        ("2018-01-25", ("2017-12-01", "2017-12-31")),
+        ("2018-09-25", ("2018-08-01", "2018-08-31")),
+    ],
+)
+def test__last_month(yyyy_mm_dd, expected):
+    # Act
+    with freeze_time(yyyy_mm_dd):
+        first, last = cli._last_month()
+
+    # Assert
+    assert expected == (first, last)
+
+
 @freeze_time("2019-05-08")
 @pytest.mark.parametrize(
     "name, expected",
@@ -53,16 +69,6 @@ class TestCli(unittest.TestCase):
         def __init__(self):
             self.json = False  # type: bool
             self.format = "markdown"  # type: str
-
-    @freeze_time("2018-09-25")
-    def test__last_month(self):
-        # Arrange
-        # Act
-        first, last = cli._last_month()
-
-        # Assert
-        self.assertEqual(first, "2018-08-01")
-        self.assertEqual(last, "2018-08-31")
 
     @freeze_time("2019-03-10")
     def test_this_month(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,7 @@ def test__month(yyyy_mm, expected):
     [
         ("2018-01-25", ("2017-12-01", "2017-12-31")),
         ("2018-09-25", ("2018-08-01", "2018-08-31")),
+        ("2018-12-25", ("2018-11-01", "2018-11-30")),
     ],
 )
 def test__last_month(yyyy_mm_dd, expected):
@@ -42,6 +43,23 @@ def test__last_month(yyyy_mm_dd, expected):
 
     # Assert
     assert expected == (first, last)
+
+
+@pytest.mark.parametrize(
+    "yyyy_mm_dd, expected",
+    [
+        ("2019-03-10", "2019-03-01"),
+        ("2019-05-08", "2019-05-01"),
+        ("2019-12-25", "2019-12-01"),
+    ],
+)
+def test__this_month(yyyy_mm_dd, expected):
+    # Act
+    with freeze_time(yyyy_mm_dd):
+        first = cli._this_month()
+
+    # Assert
+    assert expected == first
 
 
 @freeze_time("2019-05-08")
@@ -69,15 +87,6 @@ class TestCli(unittest.TestCase):
         def __init__(self):
             self.json = False  # type: bool
             self.format = "markdown"  # type: str
-
-    @freeze_time("2019-03-10")
-    def test_this_month(self):
-        # Arrange
-        # Act
-        first = cli._this_month()
-
-        # Assert
-        self.assertEqual(first, "2019-03-01")
 
     @freeze_time("2019-05-08")
     def test__month_name_to_yyyy_mm_before_now(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,31 +13,31 @@ from pypistats import cli
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "test_input, expected",
     [
         ("2018-07", ("2018-07-01", "2018-07-31")),
         ("2018-12", ("2018-12-01", "2018-12-31")),
     ],
 )
-def test__month(input, expected):
+def test__month(test_input, expected):
     # Act
-    first, last = cli._month(input)
+    first, last = cli._month(test_input)
 
     # Assert
     assert expected == (first, last)
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "test_input, expected",
     [
         ("2018-01-25", ("2017-12-01", "2017-12-31")),
         ("2018-09-25", ("2018-08-01", "2018-08-31")),
         ("2018-12-25", ("2018-11-01", "2018-11-30")),
     ],
 )
-def test__last_month(input, expected):
+def test__last_month(test_input, expected):
     # Act
-    with freeze_time(input):
+    with freeze_time(test_input):
         first, last = cli._last_month()
 
     # Assert
@@ -45,16 +45,16 @@ def test__last_month(input, expected):
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "test_input, expected",
     [
         ("2019-03-10", "2019-03-01"),
         ("2019-05-08", "2019-05-01"),
         ("2019-12-25", "2019-12-01"),
     ],
 )
-def test__this_month(input, expected):
+def test__this_month(test_input, expected):
     # Act
-    with freeze_time(input):
+    with freeze_time(test_input):
         first = cli._this_month()
 
     # Assert
@@ -84,9 +84,20 @@ def test__month_name_to_yyyy_mm(name, date_format, expected):
     assert expected == output
 
 
+@pytest.mark.parametrize("test_input", ["2018-01-12", "2018-07-12", "2018-12-12"])
+def test__valid_yyyy_mm_dd(test_input):
+    assert test_input == cli._valid_yyyy_mm_dd(test_input)
+
+
+@pytest.mark.parametrize("test_input", ["asdfsdssd", "2018-99-99", "2018-xx"])
+def test__valid_yyyy_mm_dd_invalid(test_input):
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli._valid_yyyy_mm_dd(test_input)
+
+
 @freeze_time("2019-05-08")
 @pytest.mark.parametrize(
-    "input, expected",
+    "test_input, expected",
     [
         ("jan", "2019-01"),
         ("Jan", "2019-01"),
@@ -99,8 +110,8 @@ def test__month_name_to_yyyy_mm(name, date_format, expected):
         ("december", "2018-12"),
     ],
 )
-def test__valid_yyyy_mm(input, expected):
-    assert expected == cli._valid_yyyy_mm(input)
+def test__valid_yyyy_mm(test_input, expected):
+    assert expected == cli._valid_yyyy_mm(test_input)
 
 
 class TestCli(unittest.TestCase):
@@ -108,32 +119,6 @@ class TestCli(unittest.TestCase):
         def __init__(self):
             self.json = False  # type: bool
             self.format = "markdown"  # type: str
-
-    def test__valid_yyyy_mm_dd(self):
-        # Arrange
-        input = "2018-07-12"
-
-        # Act
-        output = cli._valid_yyyy_mm_dd(input)
-
-        # Assert
-        self.assertEqual(input, output)
-
-    def test__valid_yyyy_mm_dd_invalid(self):
-        # Arrange
-        input = "asdfsdssd"
-
-        # Act / Assert
-        with self.assertRaises(argparse.ArgumentTypeError):
-            cli._valid_yyyy_mm_dd(input)
-
-    def test__valid_yyyy_mm_dd_invalid2(self):
-        # Arrange
-        input = "2018-99-99"
-
-        # Act / Assert
-        with self.assertRaises(argparse.ArgumentTypeError):
-            cli._valid_yyyy_mm_dd(input)
 
     def test__valid_yyyy_mm(self):
         # Arrange

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,32 +13,31 @@ from pypistats import cli
 
 
 @pytest.mark.parametrize(
-    "yyyy_mm, expected",
+    "input, expected",
     [
         ("2018-07", ("2018-07-01", "2018-07-31")),
         ("2018-12", ("2018-12-01", "2018-12-31")),
     ],
 )
-def test__month(yyyy_mm, expected):
-
+def test__month(input, expected):
     # Act
-    first, last = cli._month(yyyy_mm)
+    first, last = cli._month(input)
 
     # Assert
     assert expected == (first, last)
 
 
 @pytest.mark.parametrize(
-    "yyyy_mm_dd, expected",
+    "input, expected",
     [
         ("2018-01-25", ("2017-12-01", "2017-12-31")),
         ("2018-09-25", ("2018-08-01", "2018-08-31")),
         ("2018-12-25", ("2018-11-01", "2018-11-30")),
     ],
 )
-def test__last_month(yyyy_mm_dd, expected):
+def test__last_month(input, expected):
     # Act
-    with freeze_time(yyyy_mm_dd):
+    with freeze_time(input):
         first, last = cli._last_month()
 
     # Assert
@@ -46,16 +45,16 @@ def test__last_month(yyyy_mm_dd, expected):
 
 
 @pytest.mark.parametrize(
-    "yyyy_mm_dd, expected",
+    "input, expected",
     [
         ("2019-03-10", "2019-03-01"),
         ("2019-05-08", "2019-05-01"),
         ("2019-12-25", "2019-12-01"),
     ],
 )
-def test__this_month(yyyy_mm_dd, expected):
+def test__this_month(input, expected):
     # Act
-    with freeze_time(yyyy_mm_dd):
+    with freeze_time(input):
         first = cli._this_month()
 
     # Assert
@@ -64,7 +63,30 @@ def test__this_month(yyyy_mm_dd, expected):
 
 @freeze_time("2019-05-08")
 @pytest.mark.parametrize(
-    "name, expected",
+    "name, date_format, expected",
+    [
+        ("jan", "%b", "2019-01"),
+        ("Jan", "%b", "2019-01"),
+        ("january", "%B", "2019-01"),
+        ("January", "%B", "2019-01"),
+        ("feb", "%b", "2019-02"),
+        ("february", "%B", "2019-02"),
+        ("may", "%b", "2019-05"),
+        ("dec", "%b", "2018-12"),
+        ("december", "%B", "2018-12"),
+    ],
+)
+def test__month_name_to_yyyy_mm(name, date_format, expected):
+    # Act
+    output = cli._month_name_to_yyyy_mm(name, date_format)
+
+    # Assert
+    assert expected == output
+
+
+@freeze_time("2019-05-08")
+@pytest.mark.parametrize(
+    "input, expected",
     [
         ("jan", "2019-01"),
         ("Jan", "2019-01"),
@@ -77,9 +99,8 @@ def test__this_month(yyyy_mm_dd, expected):
         ("december", "2018-12"),
     ],
 )
-def test__valid_yyyy_mm(name, expected):
-    print(name, expected)
-    assert expected == cli._valid_yyyy_mm(name)
+def test__valid_yyyy_mm(input, expected):
+    assert expected == cli._valid_yyyy_mm(input)
 
 
 class TestCli(unittest.TestCase):
@@ -87,54 +108,6 @@ class TestCli(unittest.TestCase):
         def __init__(self):
             self.json = False  # type: bool
             self.format = "markdown"  # type: str
-
-    @freeze_time("2019-05-08")
-    def test__month_name_to_yyyy_mm_before_now(self):
-        # Arrange
-        input = "jan"
-        date_format = "%b"
-
-        # Act
-        output = cli._month_name_to_yyyy_mm(input, date_format)
-
-        # Assert
-        self.assertEqual(output, "2019-01")
-
-    @freeze_time("2019-05-08")
-    def test__month_name_to_yyyy_mm_before_now2(self):
-        # Arrange
-        input = "january"
-        date_format = "%B"
-
-        # Act
-        output = cli._month_name_to_yyyy_mm(input, date_format)
-
-        # Assert
-        self.assertEqual(output, "2019-01")
-
-    @freeze_time("2019-05-08")
-    def test__month_name_to_yyyy_mm_after_now(self):
-        # Arrange
-        input = "dec"
-        date_format = "%b"
-
-        # Act
-        output = cli._month_name_to_yyyy_mm(input, date_format)
-
-        # Assert
-        self.assertEqual(output, "2018-12")
-
-    @freeze_time("2019-05-08")
-    def test__month_name_to_yyyy_mm_after_now2(self):
-        # Arrange
-        input = "december"
-        date_format = "%B"
-
-        # Act
-        output = cli._month_name_to_yyyy_mm(input, date_format)
-
-        # Assert
-        self.assertEqual(output, "2018-12")
 
     def test__valid_yyyy_mm_dd(self):
         # Arrange

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,23 +100,6 @@ def test__valid_yyyy_mm_valid(test_input):
     assert test_input == cli._valid_yyyy_mm(test_input)
 
 
-@pytest.mark.parametrize("test_input", ["dfkgjskfjgk", "2018-99", "2018-xx"])
-def test__valid_yyyy_mm_invalid(test_input):
-    with pytest.raises(argparse.ArgumentTypeError):
-        cli._valid_yyyy_mm(test_input)
-
-
-@pytest.mark.parametrize("test_input", ["2019-01-21", "2019-01"])
-def test__valid_yyyy_mm_optional_dd_valid(test_input):
-    assert test_input == cli._valid_yyyy_mm_optional_dd(test_input)
-
-
-@pytest.mark.parametrize("test_input", ["dkvnf", "2018-99", "2018-xx"])
-def test__valid_yyyy_mm_optional_dd_invalid(test_input):
-    with pytest.raises(argparse.ArgumentTypeError):
-        cli._valid_yyyy_mm_optional_dd(test_input)
-
-
 @freeze_time("2019-05-08")
 @pytest.mark.parametrize(
     "test_input, expected",
@@ -132,8 +115,25 @@ def test__valid_yyyy_mm_optional_dd_invalid(test_input):
         ("december", "2018-12"),
     ],
 )
-def test__valid_yyyy_mm(test_input, expected):
+def test__valid_yyyy_mm_valid_name(test_input, expected):
     assert expected == cli._valid_yyyy_mm(test_input)
+
+
+@pytest.mark.parametrize("test_input", ["dfkgjskfjgk", "2018-99", "2018-xx"])
+def test__valid_yyyy_mm_invalid(test_input):
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli._valid_yyyy_mm(test_input)
+
+
+@pytest.mark.parametrize("test_input", ["2019-01-21", "2019-01"])
+def test__valid_yyyy_mm_optional_dd_valid(test_input):
+    assert test_input == cli._valid_yyyy_mm_optional_dd(test_input)
+
+
+@pytest.mark.parametrize("test_input", ["dkvnf", "2018-99", "2018-xx"])
+def test__valid_yyyy_mm_optional_dd_invalid(test_input):
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli._valid_yyyy_mm_optional_dd(test_input)
 
 
 class TestCli(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,22 @@ from freezegun import freeze_time
 from pypistats import cli
 
 
+@pytest.mark.parametrize(
+    "yyyy_mm, expected",
+    [
+        ("2018-07", ("2018-07-01", "2018-07-31")),
+        ("2018-12", ("2018-12-01", "2018-12-31")),
+    ],
+)
+def test__month(yyyy_mm, expected):
+
+    # Act
+    first, last = cli._month(yyyy_mm)
+
+    # Assert
+    assert expected == (first, last)
+
+
 @freeze_time("2019-05-08")
 @pytest.mark.parametrize(
     "name, expected",
@@ -37,28 +53,6 @@ class TestCli(unittest.TestCase):
         def __init__(self):
             self.json = False  # type: bool
             self.format = "markdown"  # type: str
-
-    def test__month(self):
-        # Arrange
-        yyyy_mm = "2018-07"
-
-        # Act
-        first, last = cli._month(yyyy_mm)
-
-        # Assert
-        self.assertEqual(first, "2018-07-01")
-        self.assertEqual(last, "2018-07-31")
-
-    def test__month_12(self):
-        # Arrange
-        yyyy_mm = "2018-12"
-
-        # Act
-        first, last = cli._month(yyyy_mm)
-
-        # Assert
-        self.assertEqual(first, "2018-12-01")
-        self.assertEqual(last, "2018-12-31")
 
     @freeze_time("2018-09-25")
     def test__last_month(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,11 +4,32 @@
 Unit tests for cli
 """
 import argparse
+import pytest
 import unittest
 
 from freezegun import freeze_time
 
 from pypistats import cli
+
+
+@freeze_time("2019-05-08")
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("jan", "2019-01"),
+        ("Jan", "2019-01"),
+        ("january", "2019-01"),
+        ("January", "2019-01"),
+        ("feb", "2019-02"),
+        ("february", "2019-02"),
+        ("may", "2019-05"),
+        ("dec", "2018-12"),
+        ("december", "2018-12"),
+    ],
+)
+def test__valid_yyyy_mm(name, expected):
+    print(name, expected)
+    assert expected == cli._valid_yyyy_mm(name)
 
 
 class TestCli(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,6 @@ Unit tests for cli
 """
 import argparse
 import pytest
-import unittest
 
 from freezegun import freeze_time
 
@@ -136,39 +135,34 @@ def test__valid_yyyy_mm_optional_dd_invalid(test_input):
         cli._valid_yyyy_mm_optional_dd(test_input)
 
 
-class TestCli(unittest.TestCase):
-    class __Args:
-        def __init__(self):
-            self.json = False  # type: bool
-            self.format = "markdown"  # type: str
+class __Args:
+    def __init__(self):
+        self.json = False  # type: bool
+        self.format = "markdown"  # type: str
 
-    def test__define_format_default(self):
-        # Setup
-        args = self.__Args()
-        args.json = False
 
-        _format = cli._define_format(args)
-        self.assertEqual(_format, "markdown")
+@pytest.mark.parametrize("test_input, expected", [(False, "markdown"), (True, "json")])
+def test__define_format_json_flag(test_input, expected):
+    # Arrange
+    args = __Args()
+    args.json = test_input
 
-    def test__define_format_json_flag(self):
-        args = self.__Args()
-        args.json = True
+    # Act
+    _format = cli._define_format(args)
 
-        _format = cli._define_format(args)
-        self.assertEqual(_format, "json")
+    # Assert
+    assert expected == _format
 
-    def test__define_format_json(self):
-        args = self.__Args()
-        args.json = False
-        args.format = "json"
 
-        _format = cli._define_format(args)
-        self.assertEqual(_format, "json")
+@pytest.mark.parametrize("test_input", ["json", "markdown"])
+def test__define_format_format_flag(test_input):
+    # Arrange
+    args = __Args()
+    args.json = False
+    args.format = test_input
 
-    def test__define_format_markdown(self):
-        args = self.__Args()
-        args.json = False
-        args.format = "markdown"
+    # Act
+    _format = cli._define_format(args)
 
-        _format = cli._define_format(args)
-        self.assertEqual(_format, "markdown")
+    # Assert
+    assert test_input == _format

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,54 @@ class TestCli(unittest.TestCase):
         # Assert
         self.assertEqual(first, "2019-03-01")
 
+    @freeze_time("2019-05-08")
+    def test__month_name_to_yyyy_mm_before_now(self):
+        # Arrange
+        input = "jan"
+        date_format = "%b"
+
+        # Act
+        output = cli._month_name_to_yyyy_mm(input, date_format)
+
+        # Assert
+        self.assertEqual(output, "2019-01")
+
+    @freeze_time("2019-05-08")
+    def test__month_name_to_yyyy_mm_before_now2(self):
+        # Arrange
+        input = "january"
+        date_format = "%B"
+
+        # Act
+        output = cli._month_name_to_yyyy_mm(input, date_format)
+
+        # Assert
+        self.assertEqual(output, "2019-01")
+
+    @freeze_time("2019-05-08")
+    def test__month_name_to_yyyy_mm_after_now(self):
+        # Arrange
+        input = "dec"
+        date_format = "%b"
+
+        # Act
+        output = cli._month_name_to_yyyy_mm(input, date_format)
+
+        # Assert
+        self.assertEqual(output, "2018-12")
+
+    @freeze_time("2019-05-08")
+    def test__month_name_to_yyyy_mm_after_now2(self):
+        # Arrange
+        input = "december"
+        date_format = "%B"
+
+        # Act
+        output = cli._month_name_to_yyyy_mm(input, date_format)
+
+        # Assert
+        self.assertEqual(output, "2018-12")
+
     def test__valid_yyyy_mm_dd(self):
         # Arrange
         input = "2018-07-12"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,17 @@ def test__valid_yyyy_mm_invalid(test_input):
         cli._valid_yyyy_mm(test_input)
 
 
+@pytest.mark.parametrize("test_input", ["2019-01-21", "2019-01"])
+def test__valid_yyyy_mm_optional_dd_valid(test_input):
+    assert test_input == cli._valid_yyyy_mm_optional_dd(test_input)
+
+
+@pytest.mark.parametrize("test_input", ["dkvnf", "2018-99", "2018-xx"])
+def test__valid_yyyy_mm_optional_dd_invalid(test_input):
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli._valid_yyyy_mm_optional_dd(test_input)
+
+
 @freeze_time("2019-05-08")
 @pytest.mark.parametrize(
     "test_input, expected",
@@ -130,34 +141,6 @@ class TestCli(unittest.TestCase):
         def __init__(self):
             self.json = False  # type: bool
             self.format = "markdown"  # type: str
-
-    def test__valid_yyyy_mm_optional_dd1(self):
-        # Arrange
-        input = "2019-01-21"
-
-        # Act
-        output = cli._valid_yyyy_mm_optional_dd(input)
-
-        # Assert
-        self.assertEqual(input, output)
-
-    def test__valid_yyyy_mm_optional_dd2(self):
-        # Arrange
-        input = "2019-01"
-
-        # Act
-        output = cli._valid_yyyy_mm_optional_dd(input)
-
-        # Assert
-        self.assertEqual(input, output)
-
-    def test__valid_yyyy_mm_optional_dd_invalid(self):
-        # Arrange
-        input = "dkvnf"
-
-        # Act / Assert
-        with self.assertRaises(argparse.ArgumentTypeError):
-            cli._valid_yyyy_mm_dd(input)
 
     def test__define_format_default(self):
         # Setup


### PR DESCRIPTION
Allow month names (eg. `january`) and abbreviated month names (eg. `jan`) as input for `--start-date`, `--end-date` and `--month`.

For example, these are equivalent (in May 2019):

```console
$ pypistats python_major pip --last-month
| category | percent | downloads  |
|----------|--------:|-----------:|
|        2 |  82.15% | 38,132,760 |
|        3 |  17.13% |  7,952,273 |
| null     |   0.72% |    332,180 |
| Total    |         | 46,417,213 |

$ pypistats python_major pip --month april
| category | percent | downloads  |
|----------|--------:|-----------:|
|        2 |  82.15% | 38,132,760 |
|        3 |  17.13% |  7,952,273 |
| null     |   0.72% |    332,180 |
| Total    |         | 46,417,213 |

$ pypistats python_major pip --month apr
| category | percent | downloads  |
|----------|--------:|-----------:|
|        2 |  82.15% | 38,132,760 |
|        3 |  17.13% |  7,952,273 |
| null     |   0.72% |    332,180 |
| Total    |         | 46,417,213 |

$ pypistats python_major pip --month 2019-04
| category | percent | downloads  |
|----------|--------:|-----------:|
|        2 |  82.15% | 38,132,760 |
|        3 |  17.13% |  7,952,273 |
| null     |   0.72% |    332,180 |
| Total    |         | 46,417,213 |
```

Similarly:


```console
$ pypistats python_major pip --start-date december --end-date january
| category | percent |  downloads  |
|----------|--------:|------------:|
|        2 |  87.70% | 100,274,164 |
|        3 |  11.94% |  13,653,666 |
| null     |   0.36% |     412,890 |
| Total    |         | 114,340,720 |

$ pypistats python_major pip --start-date dec --end-date jan
| category | percent |  downloads  |
|----------|--------:|------------:|
|        2 |  87.70% | 100,274,164 |
|        3 |  11.94% |  13,653,666 |
| null     |   0.36% |     412,890 |
| Total    |         | 114,340,720 |

$ pypistats python_major pip --start-date 2018-12 --end-date 2019-01
| category | percent |  downloads  |
|----------|--------:|------------:|
|        2 |  87.70% | 100,274,164 |
|        3 |  11.94% |  13,653,666 |
| null     |   0.36% |     412,890 |
| Total    |         | 114,340,720 |
```

Also refactored tests to use pytest's `@pytest.mark.parametrize` which is great for running a single test case with lots of different inputs and expected outputs!

master: 55 passed in 6.98 seconds, 171 test loc
PR: 87 passed in 6.39 seconds, 177 test loc
