### PR TITLE
setuptools_scm includes EVERYTHING in Git unless explicitly excluded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ MANIFEST
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
+pip-wheel-metadata/
 
 # Unit test / coverage reports
 htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
 
 install:
  - pip install -U pip
- - pip install -U black flake8 freezegun pytest pytest-cov requests_mock
+ - pip install -U black check-manifest flake8 freezegun pytest pytest-cov requests_mock
  - pip install -e .
 
 script:
@@ -22,6 +22,7 @@ script:
  # Static analysis
  - flake8 --statistics --count .
  - black --check --diff .
+ - check-manifest
 
  # Test runs
  - pypistats --version

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+prune .azure-pipelines
+prune example
+prune tests
+exclude .coveragerc
+exclude .editorconfig
+exclude .gitignore
+exclude .travis.yml
+exclude azure-pipelines.yml
+exclude pyproject.toml
+exclude RELEASING.md


### PR DESCRIPTION
Adding `setuptools_scm` (#59) made versioning and releasing a huge amount simpler, but inadvertently included more files:

```console
$ l /tmp/Downloads/pypistats-0.6.*
-rw-r--r--@ 1 hugo  wheel    11K 16 Jul 12:35 /tmp/Downloads/pypistats-0.6.0.tar.gz
-rw-r--r--@ 1 hugo  wheel    27K 16 Jul 12:36 /tmp/Downloads/pypistats-0.6.1.dev9.tar.gz
```

![image](https://user-images.githubusercontent.com/1324225/61284698-2ce4ca00-a7c8-11e9-91d1-ad5382340ca8.png)

See pypa/setuptools_scm#343.

Explicitly exclude/prune the other files/dirs to get it as it was before.
