### PR TITLE
Add date range to output

### DIFF
--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -223,6 +223,20 @@ def _total(data):
     return data
 
 
+def _date_range(data):
+    """Return the first and last dates in data"""
+    first = data[0]["date"]
+    last = data[0]["date"]
+    for row in data:
+        date = row["date"]
+        if date < first:
+            first = date
+        elif date > last:
+            last = date
+
+    return first, last
+
+
 def _grand_total(data):
     """Add a grand total row"""
 

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -154,7 +154,7 @@ def pypi_stats_api(
     output = _tabulate(data, format)
 
     if first:
-        return f"{output}\nDate range: {first} - {last}"
+        return f"{output}\nDate range: {first} - {last}\n"
     else:
         return output
 

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -125,6 +125,8 @@ def pypi_stats_api(
 
         _save_cache(cache_file, res)
 
+    first, last = _date_range(res["data"])
+
     if start_date or end_date:
         res["data"] = _filter(res["data"], start_date, end_date)
 
@@ -144,7 +146,12 @@ def pypi_stats_api(
     data = _percent(data)
     data = _grand_total(data)
 
-    return _tabulate(data, format)
+    output = _tabulate(data, format)
+
+    if first:
+        return f"{output}\nDate range: {first} - {last}"
+    else:
+        return output
 
 
 def _filter(data, start_date=None, end_date=None):
@@ -225,8 +232,12 @@ def _total(data):
 
 def _date_range(data):
     """Return the first and last dates in data"""
-    first = data[0]["date"]
-    last = data[0]["date"]
+    try:
+        first = data[0]["date"]
+        last = data[0]["date"]
+    except KeyError:
+        # /recent has no dates
+        return None, None
     for row in data:
         date = row["date"]
         if date < first:

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -130,6 +130,11 @@ def pypi_stats_api(
     if start_date or end_date:
         res["data"] = _filter(res["data"], start_date, end_date)
 
+    if start_date:
+        first = start_date
+    if end_date:
+        last = end_date
+
     if total == "monthly":
         res["data"] = _monthly_total(res["data"])
     elif total == "all":

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -380,6 +380,17 @@ class TestPypiStats(unittest.TestCase):
         # Assert
         self.assertEqual(output, SAMPLE_DATA_RECENT)
 
+    def test__date_range(self):
+        # Arrange
+        data = copy.deepcopy(PYTHON_MINOR_DATA)
+
+        # Act
+        first, last = pypistats._date_range(data)
+
+        # Assert
+        self.assertEqual(first, "2018-04-16")
+        self.assertEqual(last, "2018-09-23")
+
     def test__grand_total(self):
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -391,6 +391,24 @@ class TestPypiStats(unittest.TestCase):
         self.assertEqual(first, "2018-04-16")
         self.assertEqual(last, "2018-09-23")
 
+    def test__date_range_no_dates_in_data(self):
+        # Arrange
+        # recent
+        data = [
+            {
+                "data": {"last_day": 70, "last_month": 445, "last_week": 268},
+                "package": "dapy",
+                "type": "recent_downloads",
+            }
+        ]
+
+        # Act
+        first, last = pypistats._date_range(data)
+
+        # Assert
+        self.assertIsNone(first)
+        self.assertIsNone(last)
+
     def test__grand_total(self):
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)
@@ -522,6 +540,8 @@ class TestPypiStats(unittest.TestCase):
 |    category     | downloads |
 |-----------------|----------:|
 | without_mirrors | 2,297,591 |
+
+Date range: 2018-11-01 - 2018-11-02
 """
 
         # Act

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -552,6 +552,34 @@ Date range: 2018-11-02 - 2018-11-02
         # Assert
         self.assertEqual(output.strip(), expected_output.strip())
 
+    def test_overall_tabular_end_date(self):
+        # Arrange
+        package = "pip"
+        mocked_url = "https://pypistats.org/api/packages/pip/overall"
+        mocked_response = """{
+          "data": [
+            {"category": "without_mirrors", "date": "2018-11-01", "downloads": 2295765},
+            {"category": "without_mirrors", "date": "2018-11-02", "downloads": 2297591}
+          ],
+          "package": "pip",
+          "type": "overall_downloads"
+        }"""
+        expected_output = """
+|    category     | downloads |
+|-----------------|----------:|
+| without_mirrors | 2,295,765 |
+
+Date range: 2018-11-01 - 2018-11-01
+"""
+
+        # Act
+        with requests_mock.Mocker() as m:
+            m.get(mocked_url, text=mocked_response)
+            output = pypistats.overall(package, mirrors=False, end_date="2018-11-01")
+
+        # Assert
+        self.assertEqual(output.strip(), expected_output.strip())
+
     def test_python_major_json(self):
         # Arrange
         package = "pip"

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -35,6 +35,14 @@ SAMPLE_DATA_VERSION_STRINGS = [
     {"category": "3.1", "date": "2018-08-15", "downloads": 10},
     {"category": "3.10", "date": "2018-08-15", "downloads": 1},
 ]
+SAMPLE_RESPONSE_OVERALL = """{
+          "data": [
+            {"category": "without_mirrors", "date": "2018-11-01", "downloads": 2295765},
+            {"category": "without_mirrors", "date": "2018-11-02", "downloads": 2297591}
+          ],
+          "package": "pip",
+          "type": "overall_downloads"
+        }"""
 
 
 def stub__cache_filename(*args):
@@ -528,14 +536,7 @@ class TestPypiStats(unittest.TestCase):
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/overall"
-        mocked_response = """{
-          "data": [
-            {"category": "without_mirrors", "date": "2018-11-01", "downloads": 2295765},
-            {"category": "without_mirrors", "date": "2018-11-02", "downloads": 2297591}
-          ],
-          "package": "pip",
-          "type": "overall_downloads"
-        }"""
+        mocked_response = SAMPLE_RESPONSE_OVERALL
         expected_output = """
 |    category     | downloads |
 |-----------------|----------:|
@@ -556,14 +557,7 @@ Date range: 2018-11-02 - 2018-11-02
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/overall"
-        mocked_response = """{
-          "data": [
-            {"category": "without_mirrors", "date": "2018-11-01", "downloads": 2295765},
-            {"category": "without_mirrors", "date": "2018-11-02", "downloads": 2297591}
-          ],
-          "package": "pip",
-          "type": "overall_downloads"
-        }"""
+        mocked_response = SAMPLE_RESPONSE_OVERALL
         expected_output = """
 |    category     | downloads |
 |-----------------|----------:|

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -541,7 +541,7 @@ class TestPypiStats(unittest.TestCase):
 |-----------------|----------:|
 | without_mirrors | 2,297,591 |
 
-Date range: 2018-11-01 - 2018-11-02
+Date range: 2018-11-02 - 2018-11-02
 """
 
         # Act

--- a/tests/test_pypistats_cache.py
+++ b/tests/test_pypistats_cache.py
@@ -102,6 +102,8 @@ class TestPypiStatsCache(unittest.TestCase):
 |    category     | downloads |
 |-----------------|----------:|
 | without_mirrors | 2,295,765 |
+
+Date range: 2018-11-01 - 2018-11-01
 """
 
         # Act


### PR DESCRIPTION
Fixes #72. 

Because this pypistats CLI adds up the total downloads from pypistats.org ([for example](https://pypistats.org/api/packages/pip/overall)), it's not always clear what dates the downloads are for. 

For example:

```console
$ pypistats overall pip
|    category     | percent |  downloads  |
|-----------------|--------:|------------:|
| with_mirrors    |  50.39% | 349,595,890 |
| without_mirrors |  49.61% | 344,232,779 |
| Total           |         | 693,828,669 |
```

These aren't the total, all-time downloads, rather the total that are available from pypistats.org.

This PR adds a date range, where available:

```console
$ pypistats overall pip
|    category     | percent |  downloads  |
|-----------------|--------:|------------:|
| with_mirrors    |  50.39% | 349,595,890 |
| without_mirrors |  49.61% | 344,232,779 |
| Total           |         | 693,828,669 |

Date range: 2019-03-03 - 2019-08-30
```
