### PR TITLE
Add support for NumPy and Pandas data output

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ exec(pypistats.overall("pyvista",
                        table_name="downloads"))
 downloads.head()
 ```
-<table border="1" class="dataframe">
+<table class="dataframe">
   <thead>
     <tr style="text-align: right;">
       <th></th>

--- a/README.md
+++ b/README.md
@@ -217,3 +217,82 @@ print(pypistats.system("pillow", os="linux", format="rst"))
 print(pypistats.system("pillow", os="darwin", format="html"))
 pprint(pypistats.system("pillow", os="linux", format="json"))
 ```
+
+### Numpy and Pandas
+
+Return pre-formatted code to create NumPy arrays or Pandas DataFrames
+leveraging the [`pytablewriter`](https://github.com/thombashi/pytablewriter)
+package. Use the `table_name` argument to specify the variable name of the
+array/DataFrame.
+
+```python
+import pypistats
+import pandas as pd
+import numpy as np
+
+print(pypistats.overall("pyvista", total=True,
+                       format="pandas",
+                       table_name="downloads"))
+```
+```
+downloads = pd.DataFrame([
+    [ "with_mirrors" ,  "54.39%" ,  22408 ],
+    [ "without_mirrors" ,  "45.61%" ,  18789 ],
+    [ "Total" ,  None ,  41197 ],
+], columns=["category", "percent", "downloads"])
+```
+
+Instead of printing the result, call `exec()` to make the `table_name` variable
+live in the active Python session:
+
+```python
+exec(pypistats.overall("pyvista",
+                       format="pandas",
+                       table_name="downloads"))
+downloads.head()
+```
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>category</th>
+      <th>percent</th>
+      <th>downloads</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>with_mirrors</td>
+      <td>54.39%</td>
+      <td>22408</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>without_mirrors</td>
+      <td>45.61%</td>
+      <td>18789</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>Total</td>
+      <td>None</td>
+      <td>41197</td>
+    </tr>
+  </tbody>
+</table>
+</div>

--- a/README.md
+++ b/README.md
@@ -226,15 +226,12 @@ package. Use the `table_name` argument to specify the variable name of the
 array/DataFrame.
 
 ```python
-import pypistats
-import pandas as pd
-import numpy as np
-
-print(pypistats.overall("pyvista", total=True,
+>>> import pypistats
+>>> import pandas as pd
+>>> import numpy as np
+>>> print(pypistats.overall("pyvista", total=True,
                        format="pandas",
                        table_name="downloads"))
-```
-```
 downloads = pd.DataFrame([
     [ "with_mirrors" ,  "54.39%" ,  22408 ],
     [ "without_mirrors" ,  "45.61%" ,  18789 ],
@@ -246,10 +243,10 @@ Instead of printing the result, call `exec()` to make the `table_name` variable
 live in the active Python session:
 
 ```python
-exec(pypistats.overall("pyvista",
+>>> exec(pypistats.overall("pyvista",
                        format="pandas",
                        table_name="downloads"))
-downloads.head()
+>>> downloads.head()
 ```
 <table class="dataframe">
   <thead>

--- a/README.md
+++ b/README.md
@@ -251,20 +251,6 @@ exec(pypistats.overall("pyvista",
                        table_name="downloads"))
 downloads.head()
 ```
-<div>
-<style scoped>
-    .dataframe tbody tr th:only-of-type {
-        vertical-align: middle;
-    }
-
-    .dataframe tbody tr th {
-        vertical-align: top;
-    }
-
-    .dataframe thead th {
-        text-align: right;
-    }
-</style>
 <table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -295,4 +281,3 @@ downloads.head()
     </tr>
   </tbody>
 </table>
-</div>

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -17,6 +17,8 @@ from appdirs import user_cache_dir
 from pytablewriter import (
     HtmlTableWriter,
     MarkdownTableWriter,
+    NumpyTableWriter,
+    PandasDataFrameWriter,
     RstSimpleTableWriter,
     String,
 )
@@ -260,13 +262,15 @@ def _percent(data):
     return data
 
 
-def _tabulate(data, format="markdown"):
+def _tabulate(data, format="markdown", table_name="downloads"):
     """Return data in specified format"""
 
     format_writers = {
         "markdown": MarkdownTableWriter,
         "rst": RstSimpleTableWriter,
         "html": HtmlTableWriter,
+        "pandas": PandasDataFrameWriter,
+        "numpy": NumpyTableWriter,
     }
 
     writer = format_writers[format]()
@@ -284,6 +288,7 @@ def _tabulate(data, format="markdown"):
     header_list.append("downloads")
     header_list.remove("downloads")
     writer.header_list = header_list
+    writer.table_name = table_name
 
     # Custom alignment and format
     if header_list[0] in ["last_day", "last_month", "last_week"]:
@@ -299,7 +304,7 @@ def _tabulate(data, format="markdown"):
             type_hint = None
             if item == "percent":
                 align = Align.RIGHT
-            elif item == "downloads":
+            elif item == "downloads" and (format not in ["numpy", "pandas"]):
                 thousand_separator = ","
             elif item == "category":
                 type_hint = String

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -98,7 +98,7 @@ def pypi_stats_api(
     sort=True,
     total="all",
     verbose=False,
-    table_name="downloads"
+    table_name="downloads",
 ):
     """Call the API and return JSON"""
     if params:

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -98,7 +98,7 @@ def pypi_stats_api(
     sort=True,
     total="all",
     verbose=False,
-    table_name="downloads",
+    table_name=None,
 ):
     """Call the API and return JSON"""
     if params:
@@ -263,7 +263,7 @@ def _percent(data):
     return data
 
 
-def _tabulate(data, format="markdown", table_name="downloads"):
+def _tabulate(data, format="markdown", table_name=None):
     """Return data in specified format"""
 
     format_writers = {
@@ -284,6 +284,9 @@ def _tabulate(data, format="markdown", table_name="downloads"):
     else:  # isinstance(data, list):
         header_list = sorted(set().union(*(d.keys() for d in data)))
         writer.value_matrix = data
+
+    if format in ["numpy", "pandas"] and table_name is None:
+        table_name = "downloads"
 
     # Move downloads last
     header_list.append("downloads")

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -98,6 +98,7 @@ def pypi_stats_api(
     sort=True,
     total="all",
     verbose=False,
+    table_name="downloads"
 ):
     """Call the API and return JSON"""
     if params:
@@ -146,7 +147,7 @@ def pypi_stats_api(
     data = _percent(data)
     data = _grand_total(data)
 
-    return _tabulate(data, format)
+    return _tabulate(data, format, table_name)
 
 
 def _filter(data, start_date=None, end_date=None):


### PR DESCRIPTION
Now you can make NumPy arrays and Pandas DataFrames from the stats queries:

```py
import pypistats
import pandas as pd
import numpy as np

exec(pypistats.overall("pyvista", total=True, 
                       format="pandas",
                       table_name="downloads"))
downloads
```
<img width="656" alt="Screen Shot 2019-09-02 at 4 21 29 PM" src="https://user-images.githubusercontent.com/22067021/64134687-bb73d180-cd9d-11e9-8b31-fbbe69ecc8e4.png">


And you could plot the results by:

```py
mirrors = downloads.groupby("category").get_group("without_mirrors").sort_values("date")
mirrors.plot(x="date", y="downloads", figsize=(10,2))
```

![download](https://user-images.githubusercontent.com/22067021/64134776-f75b6680-cd9e-11e9-91f5-37799893e3f7.png)

