### PR TITLE
Upload coverage to Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,9 @@ jobs:
       run: |
         tox -e py`echo ${{ matrix.python-version }} | tr -d .`
 
-    # TODO Upload to Codecov
+    - name: Upload coverage to Codecov
+      run: |
+        python -m pip install --upgrade codecov
+        codecov --name "GH: ${{ matrix.os }} Python ${{ matrix.python-version }}"
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     hooks:
       - id: flake8
         language_version: python3.7
+        additional_dependencies: [flake8-2020]
 
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21


### PR DESCRIPTION
For coverage:

1. Get a Codecov upload token:
   * https://docs.codecov.io/docs/frequently-asked-questions#section-where-is-the-repository-upload-token-found- 
   * https://codecov.io/gh/hugovk/pypistats/settings

2. Save it as `CODECOV_TOKEN` at https://github.com/hugovk/pypistats/settings/secrets

This probably won't work for forks. Azure Pipelines has a workaround to "Make secrets available to builds of forks":

* https://hynek.me/articles/simple-python-azure-pipelines/#coverage

And with this AP workaround:

> Please note that this token can leak despite being a “secret” variable. A malicious user can open a PR and send it anywhere they want. However, the token is worthless for anything except uploading coverage and it’s easy to see when someone does it.

So a GHA workaround would be to put the token in plaintext.

Started a topic at the GitHub Community Forum to request "make secrets available to builds of forks":

* https://github.community/t5/GitHub-Actions/Make-secrets-available-to-builds-of-forks/m-p/30678/highlight/true#M508
