### PR TITLE
Use extras_require for test dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.24.0
+    rev: v1.24.1
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -32,4 +32,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
+      - id: check-merge-conflict
+      - id: check-toml
       - id: check-yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: python
 cache: pip
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,6 @@ max_line_length = 88
 [metadata]
 license_file = LICENSE.txt
 
-[pycodestyle]
-max_line_length = 88
-
 [tool:isort]
 force_grid_wrap = 0
 include_trailing_comma = True

--- a/setup.py
+++ b/setup.py
@@ -33,16 +33,7 @@ setup(
         "python-slugify",
         "requests",
     ],
-    extras_require={
-        "tests": [
-            "black",
-            "flake8",
-            "freezegun",
-            "pytest",
-            "pytest-cov",
-            "requests_mock",
-        ]
-    },
+    extras_require={"tests": ["freezegun", "pytest", "pytest-cov", "requests_mock"]},
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -33,14 +33,16 @@ setup(
         "python-slugify",
         "requests",
     ],
-    tests_require=[
-        "black",
-        "flake8",
-        "freezegun",
-        "pytest",
-        "pytest-cov",
-        "requests_mock",
-    ],
+    extras_require={
+        "tests": [
+            "black",
+            "flake8",
+            "freezegun",
+            "pytest",
+            "pytest-cov",
+            "requests_mock",
+        ]
+    },
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from setuptools import find_packages, setup
 
 with open("README.md") as f:

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,7 @@ envlist =
     py{36, 37, 38}
 
 [testenv]
-deps =
-    freezegun
-    pytest
-    pytest-cov
-    requests_mock
+extras = tests
 commands =
     # Unit tests
     {envpython} -m pytest --cov pypistats --cov tests {posargs}


### PR DESCRIPTION
Instead of `tests_require` in `setup.py` that's not used anywhere, and a duplicate list of `deps` in `tox.ini`.

Also update pre-commit and remove redundant pycodestyle config, also not used anywhere.