### PR TITLE
GHA: Cache pip on Windows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,16 +13,21 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: pip cache
-        uses: actions/cache@preview
+        uses: actions/cache@v1
         with:
           path: ~/.cache/pip
-          key: ${{ github.workflow }}-${{ matrix.python-version }}
+          key: ${{ matrix.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ matrix.os }}-pip-
 
       - name: pre-commit cache
-        uses: actions/cache@preview
+        uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit
-          key: ${{ github.workflow }}-${{ matrix.python-version }}
+          key:
+            ${{ matrix.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ matrix.os }}-pre-commit-
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,25 +19,37 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Ubuntu cache
-        uses: actions/cache@preview
+        uses: actions/cache@v1
         if: startsWith(matrix.os, 'ubuntu')
         with:
           path: ~/.cache/pip
-          key: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
+            }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: macOS cache
-        uses: actions/cache@preview
+        uses: actions/cache@v1
         if: startsWith(matrix.os, 'macOS')
         with:
           path: ~/Library/Caches/pip
-          key: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
+            }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: Windows cache
-        uses: actions/cache@preview
+        uses: actions/cache@v1
         if: startsWith(matrix.os, 'windows')
         with:
           path: ~\AppData\Local\pip\Cache
-          key: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**\setup.py')
+            }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,13 @@ jobs:
           path: ~/Library/Caches/pip
           key: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}
 
+      - name: Windows cache
+        uses: actions/cache@preview
+        if: startsWith(matrix.os, 'windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ github.workflow }}-${{ matrix.os }}-${{ matrix.python-version }}
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           path: ~\AppData\Local\pip\Cache
           key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**\setup.py')
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
             }}
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.python-version }}-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        # Currently:
-        # ubuntu-latest  = ubuntu-18.04
-        # macOS-latest   = macOS-10.14
-        # windows-latest = windows-2019
-        os: [ubuntu-18.04, ubuntu-16.04, macOS-10.14, windows-2019]
+        os: [ubuntu-18.04, ubuntu-16.04, macOS-latest, windows-2019]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Also update all OS caching:

* No need for `github.workflow`, it's part of cache scope:
   * "Scopes provide cache isolation and security by creating a logical boundary between different workflows and branches."
   * https://help.github.com/en/github/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#cache-scope
* Include `hashFiles('**/setup.py')`, which is where the dependencies are listed, so depend on that:
   * "Once you create a cache, you cannot change the contents of an existing cache but you can create a new cache with a new key."
* Also add `restore-keys`, so when the dependencies change, we'll still start with the last good cache:
   * "When a key doesn't match directly, the action searches for keys prefixed with the restore key. If there are multiple partial matches for a restore key, the action returns the most recently created cache."
* Plus OS-dependent `hashFiles` path to temporarily work around https://github.com/actions/cache/issues/39