### PR TITLE
Warn if --start-date is before earliest available data

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2019 Hugo van Kemenade
+Copyright (c) 2018-2020 Hugo van Kemenade
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Python 3.6+ interface to [PyPI Stats API](https://pypistats.org/api) to get aggr
 download statistics on Python packages on the Python Package Index without having to
 execute queries directly against Google BigQuery.
 
+Data is available for the [last 180 days](https://pypistats.org/about#data). (For longer
+time periods, [pypinfo](https://github.com/ofek/pypinfo) can help, you'll need an API
+key and get free quota.)
+
 ## Installation
 
 ### From PyPI

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -7,6 +7,7 @@ import atexit
 import datetime as dt
 import json
 import sys
+import warnings
 from pathlib import Path
 
 import pkg_resources
@@ -125,7 +126,16 @@ def pypi_stats_api(
 
         _save_cache(cache_file, res)
 
+    # Actual first and last dates of the fetched data
     first, last = _date_range(res["data"])
+
+    if start_date and start_date < first:
+        warnings.warn(
+            f"Requested start date ({start_date}) is before earliest available "
+            f"data ({first}), because data is only available for 180 days. "
+            "See https://pypistats.org/about#data",
+            stacklevel=3,
+        )
 
     if start_date or end_date:
         res["data"] = _filter(res["data"], start_date, end_date)

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -119,6 +119,27 @@ class TestPypiStats(unittest.TestCase):
             self.assertGreaterEqual(row["date"], start_date)
             self.assertLessEqual(row["date"], end_date)
 
+    def test_warn_if_start_date_before_earliest_available(self):
+        # Arrange
+        start_date = "2000-01-01"
+        package = "pip"
+        mocked_url = "https://pypistats.org/api/packages/pip/python_major"
+        mocked_response = """{
+            "data": [
+                {"category": "2", "date": "2018-11-01", "downloads": 2008344},
+                {"category": "3", "date": "2018-11-01", "downloads": 280299},
+                {"category": "null", "date": "2018-11-01", "downloads": 7122}
+            ],
+            "package": "pip",
+            "type": "python_major_downloads"
+        }"""
+
+        with requests_mock.Mocker() as m:
+            m.get(mocked_url, text=mocked_response)
+            # Act / Assert
+            with self.assertWarns(UserWarning):
+                pypistats.python_major(package, start_date=start_date)
+
     def test__paramify_none(self):
         # Arrange
         period = None


### PR DESCRIPTION
Fixes #85.

Add info to README and show a warning when called with `--start-date` before the earliest available data:


```console
$ pypistats python_major torchtext --start-date 2019-06-01 --end-date 2019-06-30
/Users/hugo/github/pypistats/src/pypistats/cli.py:232: UserWarning: Requested start date (2019-06-01) is before earliest available data (2019-07-07), because data is only available for 180 days. See https://pypistats.org/about#data
  verbose=args.verbose,
| category | downloads |
|----------|----------:|
| Total    |         0 |

Date range: 2019-06-01 - 2019-06-30
```

Warning not an error, because end date can be in range:

```console
$ pypistats python_major torchtext --start-date 2019-06-01
/Users/hugo/github/pypistats/src/pypistats/cli.py:232: UserWarning: Requested start date (2019-06-01) is before earliest available data (2019-07-07), because data is only available for 180 days. See https://pypistats.org/about#data
  verbose=args.verbose,
| category | percent | downloads |
|----------|--------:|----------:|
| 3        |  94.26% |   177,080 |
| 2        |   5.09% |     9,559 |
| null     |   0.66% |     1,234 |
| Total    |         |   187,873 |

Date range: 2019-06-01 - 2020-01-03
```

Perhaps an error could be shown when `--end-date` is before earliest available data?
