### PR TITLE
Error if --end-date is before earliest available data

### DIFF
--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -129,6 +129,15 @@ def pypi_stats_api(
     # Actual first and last dates of the fetched data
     first, last = _date_range(res["data"])
 
+    # Validate end date
+    if end_date and end_date < first:
+        raise ValueError(
+            f"Requested end date ({end_date}) is before earliest available "
+            f"data ({first}), because data is only available for 180 days. "
+            "See https://pypistats.org/about#data"
+        )
+
+    # Validate start date
     if start_date and start_date < first:
         warnings.warn(
             f"Requested start date ({start_date}) is before earliest available "

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -137,8 +137,39 @@ class TestPypiStats(unittest.TestCase):
         with requests_mock.Mocker() as m:
             m.get(mocked_url, text=mocked_response)
             # Act / Assert
-            with self.assertWarns(UserWarning):
+            with self.assertWarnsRegex(
+                UserWarning,
+                r"Requested start date \(2000-01-01\) is before earliest available "
+                r"data \(2018-11-01\), because data is only available for 180 days. "
+                "See https://pypistats.org/about#data",
+            ):
                 pypistats.python_major(package, start_date=start_date)
+
+    def test_error_if_end_date_before_earliest_available(self):
+        # Arrange
+        end_date = "2000-01-01"
+        package = "pip"
+        mocked_url = "https://pypistats.org/api/packages/pip/python_major"
+        mocked_response = """{
+            "data": [
+                {"category": "2", "date": "2018-11-01", "downloads": 2008344},
+                {"category": "3", "date": "2018-11-01", "downloads": 280299},
+                {"category": "null", "date": "2018-11-01", "downloads": 7122}
+            ],
+            "package": "pip",
+            "type": "python_major_downloads"
+        }"""
+
+        with requests_mock.Mocker() as m:
+            m.get(mocked_url, text=mocked_response)
+            # Act / Assert
+            with self.assertRaisesRegex(
+                ValueError,
+                r"Requested end date \(2000-01-01\) is before earliest available "
+                r"data \(2018-11-01\), because data is only available for 180 days. "
+                "See https://pypistats.org/about#data",
+            ):
+                pypistats.python_major(package, end_date=end_date)
 
     def test__paramify_none(self):
         # Arrange


### PR DESCRIPTION
Follow on from https://github.com/hugovk/pypistats/pull/86, for #85.

```console
$ pypistats python_major torchtext --start-date 2019-06-01 --end-date 2019-12-31
/Users/hugo/github/pypistats/src/pypistats/cli.py:232: UserWarning: Requested start date (2019-06-01) is before earliest available data (2019-07-09), because data is only available for 180 days. See https://pypistats.org/about#data
  verbose=args.verbose,
| category | percent | downloads |
|----------|--------:|----------:|
| 3        |  94.27% |   176,154 |
| 2        |   5.09% |     9,505 |
| null     |   0.64% |     1,201 |
| Total    |         |   186,860 |

Date range: 2019-06-01 - 2019-12-31

$ pypistats python_major torchtext --start-date 2019-06-01 --end-date 2019-06-30
Traceback (most recent call last):
  File "/usr/local/bin/pypistats", line 11, in <module>
    load_entry_point('pypistats', 'console_scripts', 'pypistats')()
  File "/Users/hugo/github/pypistats/src/pypistats/cli.py", line 337, in main
    args.func(args)
  File "/Users/hugo/github/pypistats/src/pypistats/cli.py", line 232, in python_major
    verbose=args.verbose,
  File "/Users/hugo/github/pypistats/src/pypistats/__init__.py", line 402, in python_major
    return pypi_stats_api(endpoint, params, **kwargs)
  File "/Users/hugo/github/pypistats/src/pypistats/__init__.py", line 135, in pypi_stats_api
    f"Requested end date ({end_date}) is before earliest available "
ValueError: Requested end date (2019-06-30) is before earliest available data (2019-07-09), because data is only available for 180 days. See https://pypistats.org/about#data
```