### PR TITLE
Test Python 3.9 alpha on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - python: 3.8
     - python: 3.7
     - python: 3.6
+    - python: 3.9-dev
 
 install:
   - pip install -U pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 max_line_length = 88
 
 [tool:isort]
-known_third_party = appdirs,dateutil,freezegun,numpy,pandas,pkg_resources,pypistats,pytablewriter,pytest,requests,requests_mock,setuptools,slugify
+known_third_party = appdirs,dateutil,freezegun,pkg_resources,pypistats,pytablewriter,pytest,requests,requests_mock,setuptools,slugify
 force_grid_wrap = 0
 include_trailing_comma = True
 line_length = 88

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -7,13 +7,21 @@ import json
 import unittest
 from pathlib import Path
 
-import numpy
-import pandas
 import pypistats
 import requests_mock
 
 from .data.python_minor import DATA as PYTHON_MINOR_DATA
 from .data.tabulated_rst import DATA as EXPECTED_TABULATED_RST
+
+try:
+    import numpy
+except ImportError:
+    numpy = None
+try:
+    import pandas
+except ImportError:
+    pandas = None
+
 
 SAMPLE_DATA = [
     {"category": "2.6", "date": "2018-08-15", "downloads": 51},
@@ -774,6 +782,7 @@ Date range: 2018-11-01 - 2018-11-01
         # Assert
         self.assertEqual(output.strip(), expected_output.strip())
 
+    @unittest.skipIf(numpy is None, "NumPy is not installed")
     def test_format_numpy(self):
         # Arrange
         package = "pip"
@@ -790,6 +799,7 @@ Date range: 2018-11-01 - 2018-11-01
         self.assertIsInstance(output, numpy.ndarray)
         self.assertEqual(str(output), expected_output)
 
+    @unittest.skipIf(pandas is None, "pandas is not installed")
     def test_format_pandas(self):
         # Arrange
         package = "pip"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{36, 37, 38}
+    py{36, 37, 38, 39}
 
 [testenv]
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -21,3 +21,7 @@ commands =
 deps = pre-commit
 commands = pre-commit run --all-files
 skip_install = true
+
+[testenv:py39]
+# NumPy and pandas' dependency Cython doesn't yet support Python 3.9
+extras = tests


### PR DESCRIPTION
NumPy and pandas' dependency Cython doesn't yet support Python 3.9 (https://github.com/cython/cython/issues/3266), so skip those tests for now. 