### PR TITLE
Simplify config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,8 @@ jobs:
 
       - name: Tox tests
         shell: bash
-        # Drop the dot: py3.7 -> py37
         run: |
-          tox -e py`echo ${{ matrix.python-version }} | tr -d .`
+          tox -e py
 
       - name: Upload coverage to Codecov
         run: |


### PR DESCRIPTION
`tox -e py` will use the interpreter tox is installed to