### PR TITLE
Only Python 3 is supported: don't create universal wheel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.1
+    rev: v1.26.2
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -25,8 +25,8 @@ repos:
     hooks:
       - id: seed-isort-config
 
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21
     hooks:
       - id: isort
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max_line_length = 88
 


### PR DESCRIPTION
The wheel filename contains `py2.py3`, indicating Python 2 support:

![image](https://user-images.githubusercontent.com/1324225/73731111-91ee1600-4740-11ea-812f-4e4eabfaf178.png)

https://pypi.org/project/pypistats/0.10.0/#files

# Universal Wheels

> _Universal Wheels_ are wheels that are pure Python (i.e. contain no compiled extensions) and support Python 2 and 3. This is a wheel that can be installed anywhere by pip.
...
> Only use the `--universal` setting, if:
> * Your project runs on Python 2 and 3 with no changes (i.e. it does not require 2to3).
> * Your project does not have any C extensions.
>
> Beware that `bdist_wheel` does not currently have any checks to warn if you use the setting inappropriately.

https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels

# Pure Python Wheels

> _Pure Python Wheels_ that are not “universal” are wheels that are pure Python (i.e. contain no compiled extensions), but don’t natively support both Python 2 and 3.
...
> `bdist_wheel` will detect that the code is pure Python, and build a wheel that’s named such that it’s usable on any Python installation with the same major version (Python 2 or Python 3) as the version you used to build the wheel.

https://packaging.python.org/guides/distributing-packages-using-setuptools/#pure-python-wheels
