### PR TITLE
Add GitHub Action to create a release from a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "*"
+
+name: Create release
+
+jobs:
+  build:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            * TODO
+          draft: false
+          prerelease: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,9 +19,7 @@ git tag -a 0.1.0 -m "Release 0.1.0"
 git push --tags
 ```
 
-- [ ] Create new GitHub release: https://github.com/hugovk/pypistats/releases/new
-
-  - Tag: Pick existing tag "0.1.0"
+- [ ] Edit new GitHub release: https://github.com/hugovk/pypistats/releases
 
 - [ ] Check the tagged [Travis CI build](https://travis-ci.org/hugovk/pypistats) has
       deployed to [PyPI](https://pypi.org/project/pypistats/#history)


### PR DESCRIPTION
Uses https://github.com/actions/create-release to simplify the release process.

When pushing a tag, this will create a corresponding release at https://github.com/hugovk/pypistats/releases.

Note: The body text won't be created as "* TODO" from the config, but "Release [x.y.z]". This has been fixed in the action, but not yet released: https://github.com/actions/create-release/issues/38.
