### PR TITLE
Require pytablewriter 0.48+ to fix NumpyTableWriter regression

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,12 +31,12 @@ repos:
       - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.4
+    rev: v1.5.1
     hooks:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     setup_requires=["setuptools_scm"],
     install_requires=[
         "appdirs",
-        "pytablewriter[html]>=0.41.2",
+        "pytablewriter[html]>=0.48",
         "python-dateutil",
         "python-slugify",
         "requests",

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -325,34 +325,34 @@ def _tabulate(data, format="markdown"):
         writer.margin = 1
 
     if isinstance(data, dict):
-        header_list = list(data.keys())
+        headers = list(data.keys())
         writer.value_matrix = [data]
     else:  # isinstance(data, list):
-        header_list = sorted(set().union(*(d.keys() for d in data)))
+        headers = sorted(set().union(*(d.keys() for d in data)))
         writer.value_matrix = data
 
     # Move downloads last
-    header_list.append("downloads")
-    header_list.remove("downloads")
-    writer.header_list = header_list
+    headers.append("downloads")
+    headers.remove("downloads")
+    writer.headers = headers
 
     # Custom alignment and format
-    if header_list[0] in ["last_day", "last_month", "last_week"]:
+    if headers[0] in ["last_day", "last_month", "last_week"]:
         # Special case for 'recent'
-        writer.column_styles = len(header_list) * [Style(thousand_separator=",")]
+        writer.column_styles = len(headers) * [Style(thousand_separator=",")]
     else:
         column_styles = []
         type_hints = []
 
-        for item in header_list:
+        for header in headers:
             align = None
             thousand_separator = None
             type_hint = None
-            if item == "percent":
+            if header == "percent":
                 align = Align.RIGHT
-            elif item == "downloads" and (format not in ["numpy", "pandas"]):
+            elif header == "downloads" and (format not in ["numpy", "pandas"]):
                 thousand_separator = ","
-            elif item == "category":
+            elif header == "category":
                 type_hint = String
             style = Style(align=align, thousand_separator=thousand_separator)
             column_styles.append(style)

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -21,7 +21,7 @@ from pytablewriter import (
     RstSimpleTableWriter,
     String,
 )
-from pytablewriter.style import Align, Style
+from pytablewriter.style import Align, Style, ThousandSeparator
 from slugify import slugify
 
 __version__ = pkg_resources.get_distribution(__name__).version
@@ -346,7 +346,7 @@ def _tabulate(data, format="markdown"):
 
         for header in headers:
             align = None
-            thousand_separator = None
+            thousand_separator = ThousandSeparator.NONE
             type_hint = None
             if header == "percent":
                 align = Align.RIGHT

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -339,9 +339,9 @@ def _tabulate(data, format="markdown"):
     # Custom alignment and format
     if header_list[0] in ["last_day", "last_month", "last_week"]:
         # Special case for 'recent'
-        writer.style_list = len(header_list) * [Style(thousand_separator=",")]
+        writer.column_styles = len(header_list) * [Style(thousand_separator=",")]
     else:
-        style_list = []
+        column_styles = []
         type_hints = []
 
         for item in header_list:
@@ -355,10 +355,10 @@ def _tabulate(data, format="markdown"):
             elif item == "category":
                 type_hint = String
             style = Style(align=align, thousand_separator=thousand_separator)
-            style_list.append(style)
+            column_styles.append(style)
             type_hints.append(type_hint)
 
-        writer.style_list = style_list
+        writer.column_styles = column_styles
         writer.type_hints = type_hints
 
     if format == "numpy":


### PR DESCRIPTION
* Introduced in pytablewriter 0.47, fixed by https://github.com/thombashi/pytablewriter/issues/25 in 0.48
* Fix initialisation of `thousand_separator` to `ThousandSeparator.NONE` instead of `None`
* Fix a couple of new deprecation warnings
