### PR TITLE
Codecov now supports tokenless upload for GHA

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
         python-version: [3.8]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: pip cache
         uses: actions/cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,16 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-latest]
+        include:
+          # Include new variables for Codecov
+          - os: ubuntu-18.04
+            codecov-flag: GHA_Ubuntu_18
+          - os: ubuntu-16.04
+            codecov-flag: GHA_Ubuntu_16
+          - os: macOS-latest
+            codecov-flag: GHA_macOS
+          - os: windows-latest
+            codecov-flag: GHA_Windows
 
     steps:
       - uses: actions/checkout@v1
@@ -62,9 +72,10 @@ jobs:
         run: |
           tox -e py
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage
+        if: success()
         run: |
-          python -m pip install --upgrade codecov
-          codecov --name "GH: ${{ matrix.os }} Python ${{ matrix.python-version }}"
+          curl -s https://codecov.io/bash -o codecov.sh
+          bash codecov.sh -F ${{ matrix.codecov-flag }}
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_NAME: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
             codecov-flag: GHA_Windows
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Ubuntu cache
         uses: actions/cache@v1

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ extras =
     tests
 commands =
     # Unit tests
-    {envpython} -m pytest --cov pypistats --cov tests {posargs}
+    {envpython} -m pytest --cov pypistats --cov tests --cov-report xml {posargs}
 
     # Test runs
     pypistats --version


### PR DESCRIPTION
Codecov now supports tokenless uploads for GitHub Actions.

* https://community.codecov.io/t/whitelist-github-action-servers-to-upload-without-a-token/491/17

And include some flags for extra visibility on coverage reports.