### PR TITLE
Default align to Align.AUTO not None

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.0
+    rev: v2.1.1
     hooks:
       - id: seed-isort-config
 
@@ -43,7 +43,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.2
+    rev: 2.0.4
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -347,7 +347,7 @@ def _tabulate(data, format="markdown"):
         type_hints = []
 
         for header in headers:
-            align = None
+            align = Align.AUTO
             thousand_separator = ThousandSeparator.NONE
             type_hint = None
             if header == "percent":


### PR DESCRIPTION
Fixes https://github.com/hugovk/pypistats/issues/101, for latest pytablewriter v0.51.0.