### PR TITLE
Remove linting from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ matrix:
   fast_finish: true
   include:
     - python: 3.8
-      env: TOXENV=lint
-    - python: 3.8
+      env: DEPLOY=true
     - python: 3.7
     - python: 3.6
     - python: 3.9-dev
@@ -23,9 +22,7 @@ script:
 
 after_success:
   - |
-    if [ "$TOXENV" != "lint" ]; then
-      pip install -U codecov && codecov
-    fi
+    pip install -U codecov && codecov
 
 deploy:
   - provider: pypi
@@ -34,7 +31,7 @@ deploy:
       tags: false
       repo: hugovk/pypistats
       branch: master
-      condition: $TOXENV = lint
+      condition: $DEPLOY = true
     user: __token__
     password:
       secure: "pG6CQh9N751gth+M0l2mdAJjlY/OMq4nYEgDwAgvtE+h4nPjGic34+ZG3jzxFQOtLgLEOeJq6AYg6Yytl/vCBBR1pUOYzqWdn0ekmJZQSsMPR7RRnjtzjXxrNiqtrtGPcr/51tCtMCZAEVPE/gApymED86bqZurcM2uWMSNlo3mVNSxU2UKVrvwuHvunQ1bzve76anTlIgGpAS+DbWgyGsP7zYErFTWmiJ5sVk0gIkpK3NTJyLgjv3vLGb3hx6oesiuT5o9NJ6A9pShLGtrUEgqDKWCdXgr6QxlLY6Zhvcs0mBEcfSJdV0aZi/AxSjIUr3AiqWHeyWn5OSUJfx+6+283Gp2CMFDRSvj1p3Ng3Tby8HN+JRyrMrtqFNZ0E3tKXYOeUF3pd27hLM596fbM+qAz37zsYqBjG18CeSBV8OrwEvF9M4Ot8A1ZPi+zfjU5nrPxhzm6VnInMI0ioMO/zUinIOtSkYSHRIohww5mm2yIE2xRAO/64H0papbrK1xz+xMrmzLkJMY0DwrgZQhMK2/vYHhVa0wytjop42tQ17EkWfHE8waXLD0MQFEB+H3TMGBnsqf+jrcKpfwnhVye3KwFnU/2geuPB1dI6ohf7ucy3b/oNLe4fB9Pf8DQK/noGLmNBXQ2lrtTD0pblRLzsRc8LSyVLXu0fZIWUovubLU="
@@ -45,7 +42,7 @@ deploy:
       tags: true
       repo: hugovk/pypistats
       branch: master
-      condition: $TOXENV = lint
+      condition: $DEPLOY = true
     user: __token__
     password:
       secure: "dNoI5yPvDksuDxh7go1sZhmpA94zrsNDYHA4nTj+HMgUx7ITZbeRkIna0QWMms29mI4j7JlywuopSE78cKkjG2aZjSGhT4h5AmrRmWFhJDV7Qj4wghevPHNRRkQkUK3+ciFRDkkBb0J6dxgylmtz0OGTxWePyCfFoO9gmQycrSkcwUi2S89aS701xFYFOQQVcAMud3J9GCM4qLURmD2PO6DFIUNTI2AjPgxlZqVh9zAkwmE3huwIdZNBwJ7Rz6pXxSvkZ0gLFD7324Nox2cJ24J2sXSyfTUDqV/FkvOXDqD8vFI/iDLplwwB8uWQgPCw3xX6Lu+SVY9E/ClhIfkPMvDBQwIwRRxtx16W27mqjOIw/vTloMym4KunEcsZIvNbFZcg9S5zUcCIoMblDLl0FbSlpuyEua1LlpxWrQ2+QR6clVdwY4kH/tjcDKyKxQQkaSOWLLsv5uYpRebsgRuXcCbnNi69Go2bYQpJrWSKRztgLn9uCWEivlsqN8DD3m1DD+/pdn7v79gH32W2lYwZ8vovOLMJZYZ9zg3k/0wLyRfarihd9TYrvPMAnXcut93BLBKq5aNXDsgsaswGZLEFDb+VVzwjucReEE8msUyYQvOl3qBVeKwoDaSK2LeuJHz45gUoODQeFI9l1UpI7ZZYbeQqdVzYp5WCRb6FUU1yq14="


### PR DESCRIPTION
The latest `master` cron build on Travis failed:

```
pyupgrade................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
seed isort known_third_party.............................................Passed
isort....................................................................Passed
check blanket noqa.......................................................Passed
Check for merge conflicts................................................Passed
Check Toml...............................................................Passed
Check Yaml...............................................................Passed
prettier.................................................................Failed
- hook id: prettier
- exit code: 1
prettier requires at least version 10.13.0 of Node, please upgrade
prettier requires at least version 10.13.0 of Node, please upgrade
```

https://travis-ci.org/github/hugovk/pypistats/jobs/680199511#L241

The previous `master` cron build passed:

https://travis-ci.org/github/hugovk/pypistats/builds/677342915

Lint is also done on GitHub Actions, and passing, let's just remove linting from Travis CI.

Let's also add a similar cron to GHA in another PR.