### PR TITLE
Test with pinned dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,12 @@ jobs:
         run: |
           tox -e py
 
+      - name: Tox tests (pins)
+        if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-18.04'
+        shell: bash
+        run: |
+          tox -e pins
+
       - name: Upload coverage
         if: success()
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
+      - id: requirements-txt-fixer
 
   - repo: https://github.com/prettier/prettier
     rev: 2.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# Only for testing pinned versions on the CI
+appdirs==1.4.3
+freezegun==0.3.15
+numpy==1.18.2
+pandas==1.0.0
+pytablewriter[html]==0.48
+pytest==5.4.1
+pytest-cov==2.8.1
+python-slugify==4.0.0
+requests==2.22.0
+requests_mock==1.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     lint
     py{36, 37, 38, 39}
+    pins
 
 [testenv]
 extras =
@@ -16,6 +17,11 @@ commands =
     pypistats --version
     pypistats --help
     pypistats recent --help
+
+[testenv:pins]
+extras = None
+commands_pre =
+    {envpython} -m pip install -r requirements.txt
 
 [testenv:lint]
 deps = pre-commit


### PR DESCRIPTION
Add an extra `tox -e pins` to the Python 3.8+Ubuntu 18.04 job on GHA, so it can test pinned deps.

This means dependabot can be used to bump and test new pins.
