### PR TITLE
GHA: Add automerge

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -49,6 +49,9 @@
   name: "changelog: skip"
 
 # Other labels
+- color: 2d18b2
+  description: "To automatically merge PRs that are ready"
+  name: automerge
 - color: fbca04
   description: "Unit tests, linting, CI, etc."
   name: testing

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,28 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@80acb0f883348dcfd0e526288f7d27a12b9333be"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_REMOVE_LABELS: "automerge"


### PR DESCRIPTION
Add GitHub Action to automerge.

Uses default config, plus removes the label once merged.

The GHA lint + test and Travis CI and top-level Azure Pipelines jobs have been marked as required in https://github.com/hugovk/pypistats/settings/branch_protection_rules/5419682