### PR TITLE
GHA: Force colour output

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,3 +37,5 @@ jobs:
 
       - name: Lint
         run: tox -e lint
+        env:
+          PRE_COMMIT_COLOR: always

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ include_trailing_comma = True
 line_length = 88
 multi_line_output = 3
 use_parentheses = True
+
+[tool:pytest]
+addopts = --color=yes

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands_pre =
 deps = pre-commit
 commands = pre-commit run --all-files
 skip_install = true
+passenv = PRE_COMMIT_COLOR
 
 [testenv:py39]
 # NumPy and pandas' dependency Cython doesn't yet support Python 3.9


### PR DESCRIPTION
GitHub Actions doesn't have coloured output by default, it must be forced, where the tool allows.