### PR TITLE
GHA: Cache multiple paths

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,24 +9,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: pip cache
-        uses: actions/cache@v1
+      - name: Cache
+        uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
-          key: lint-pip-${{ hashFiles('**/setup.py') }}
+          path: |
+            ~/.cache/pip
+            ~/.cache/pre-commit
+          key:
+            lint-v2-${{ hashFiles('**/setup.py') }}-${{
+            hashFiles('**/.pre-commit-config.yaml') }}
           restore-keys: |
-            lint-pip-
+            lint-v2-
 
-      - name: pre-commit cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pre-commit
-          key: lint-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
-          restore-keys: |
-            lint-pre-commit-
-
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -32,7 +32,7 @@ jobs:
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key:


### PR DESCRIPTION
Version 2 of GitHub Actions cache allows caching multiple paths:

* https://github.com/actions/cache/releases/tag/v2.0.0
