### PR TITLE
Update isort to v5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,13 +20,8 @@ repos:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.1.1
-    hooks:
-      - id: seed-isort-config
-
   - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+    rev: 5.3.2
     hooks:
       - id: isort
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,12 +2,7 @@
 max_line_length = 88
 
 [tool:isort]
-known_third_party = appdirs,dateutil,freezegun,pkg_resources,pypistats,pytablewriter,pytest,requests,requests_mock,setuptools,slugify
-force_grid_wrap = 0
-include_trailing_comma = True
-line_length = 88
-multi_line_output = 3
-use_parentheses = True
+profile = black
 
 [tool:pytest]
 addopts = --color=yes

--- a/src/pypistats/cli.py
+++ b/src/pypistats/cli.py
@@ -5,8 +5,9 @@ CLI with subcommands for pypistats
 import argparse
 import datetime as dt
 
-import pypistats
 from dateutil.relativedelta import relativedelta
+
+import pypistats
 
 cli = argparse.ArgumentParser()
 subparsers = cli.add_subparsers(dest="subcommand")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import argparse
 
 import pytest
 from freezegun import freeze_time
+
 from pypistats import cli
 
 

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -5,9 +5,10 @@ import copy
 import json
 from pathlib import Path
 
-import pypistats
 import pytest
 import requests_mock
+
+import pypistats
 
 from .data.expected_tabulated import (
     EXPECTED_TABULATED_HTML,

--- a/tests/test_pypistats_cache.py
+++ b/tests/test_pypistats_cache.py
@@ -4,9 +4,10 @@ Unit tests for pypistats cache
 import tempfile
 from pathlib import Path
 
-import pypistats
 import requests_mock
 from freezegun import freeze_time
+
+import pypistats
 
 
 class TestPypiStatsCache:


### PR DESCRIPTION
Can use the Black profile, and no longer need `seed-isort-config`.

Plus some minor GHA workflow updates.
