### PR TITLE
Fixed overall table information, fixing issue #177

### DIFF
--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -169,7 +169,7 @@ def pypi_stats_api(
         data = _sort(data)
 
     if res["type"] == "overall_downloads":
-        data = _fixCategories(data)
+        data = _fix_categories(data)
     else:
         data = _percent(data)
         data = _grand_total(data)
@@ -182,7 +182,7 @@ def pypi_stats_api(
         return output
 
 
-def _fixCategories(data):
+def _fix_categories(data):
     """Fix the categories so naming is correct and add correct total row"""
 
     # Only for lists of dicts, not a single dict
@@ -196,20 +196,14 @@ def _fixCategories(data):
     dataDict = {}
     for dataPiece in data:
         dataDict[dataPiece["category"]] = dataPiece["downloads"]
-    
+
     totalDownloads = dataDict["with_mirrors"]
     endUsers = dataDict["without_mirrors"]
     mirrorDownloads = totalDownloads - endUsers
 
     data = [
-        {
-            "category": "End Users",
-            "downloads": endUsers
-        },
-        {
-            "category": "Mirrors",
-            "downloads": mirrorDownloads
-        }
+        {"category": "End Users", "downloads": endUsers},
+        {"category": "Mirrors", "downloads": mirrorDownloads},
     ]
 
     new_row = {"category": "Total", "downloads": totalDownloads}


### PR DESCRIPTION
I've changed the way the data is manipulated when you request overall statistics. Before this fix, the table for overall looked like this:
|    category     | percent | downloads |
|-----------------|--------:|----------:|
| with_mirrors    |  85.66% |       239 |
| without_mirrors |  14.34% |        40 |
| Total           |         |       279 |

Which has an incorrect value for the total row as with_mirrors is actually the total *including* mirrors (the naming is confusing, but that's the API's fault). Now, the table looks like this:
| category  | downloads |
|-----------|----------:|
| End Users |        40 |
| Mirrors   |       199 |
| Total     |       239 |