### PR TITLE
Convert setup.py to static setup.cfg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: ["--py36-plus"]
 
   - repo: https://github.com/psf/black
-    rev: 21.4b2
+    rev: 21.5b0
     hooks:
       - id: black
         args: ["--target-version", "py36"]
@@ -37,6 +37,11 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: requirements-txt-fixer
+
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.17.0
+    hooks:
+      - id: setup-cfg-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,17 +3,10 @@ name = pypistats
 description = Python interface to PyPI Stats API https://pypistats.org/api
 long_description = file: README.md
 long_description_content_type = text/markdown
-author = hugovk
 url = https://github.com/hugovk/pypistats
-project_urls =
-    Source=https://github.com/hugovk/pypistats
+author = hugovk
 license = MIT
-keywords =
-    PyPI
-    downloads
-    statistics
-    stats
-    BigQuery
+license_file = LICENSE.txt
 classifiers =
     Development Status :: 3 - Alpha
     Intended Audience :: Developers
@@ -21,18 +14,23 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
+keywords =
+    PyPI
+    downloads
+    statistics
+    stats
+    BigQuery
+project_urls =
+    Source=https://github.com/hugovk/pypistats
 
 [options]
 packages = find:
-package_dir = =src
-zip_safe = True
-setup_requires = setuptools_scm
 install_requires =
     appdirs
     httpx>=0.13,<0.19
@@ -40,6 +38,10 @@ install_requires =
     python-dateutil
     python-slugify
 python_requires = >=3.6
+package_dir = =src
+setup_requires =
+    setuptools_scm
+zip_safe = True
 
 [options.packages.find]
 where = src
@@ -49,8 +51,10 @@ console_scripts =
     pypistats = pypistats.cli:main
 
 [options.extras_require]
-numpy = numpy
-pandas = pandas
+numpy =
+    numpy
+pandas =
+    pandas
 tests =
     freezegun
     pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,62 @@
+[metadata]
+name = pypistats
+description = Python interface to PyPI Stats API https://pypistats.org/api
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = hugovk
+url = https://github.com/hugovk/pypistats
+project_urls =
+    Source=https://github.com/hugovk/pypistats
+license = MIT
+keywords =
+    PyPI
+    downloads
+    statistics
+    stats
+    BigQuery
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    Intended Audience :: End Users/Desktop
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: Implementation :: CPython
+
+[options]
+packages = find:
+package_dir = =src
+zip_safe = True
+setup_requires = setuptools_scm
+install_requires =
+    appdirs
+    httpx>=0.13,<0.19
+    pytablewriter[html]>=0.49
+    python-dateutil
+    python-slugify
+python_requires = >=3.6
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    pypistats = pypistats.cli:main
+
+[options.extras_require]
+numpy = numpy
+pandas = pandas
+tests =
+    freezegun
+    pytest
+    pytest-cov
+    respx>=0.11
+
 [flake8]
 max_line_length = 88
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
-from setuptools import find_packages, setup
-
-with open("README.md") as f:
-    long_description = f.read()
+from setuptools import setup
 
 
 def local_scheme(version):
@@ -11,46 +8,5 @@ def local_scheme(version):
 
 
 setup(
-    name="pypistats",
-    description="Python interface to PyPI Stats API https://pypistats.org/api",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="hugovk",
-    url="https://github.com/hugovk/pypistats",
-    project_urls={"Source": "https://github.com/hugovk/pypistats"},
-    license="MIT",
-    keywords=["PyPI", "downloads", "statistics", "stats", "BigQuery"],
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
-    entry_points={"console_scripts": ["pypistats = pypistats.cli:main"]},
-    zip_safe=True,
     use_scm_version={"local_scheme": local_scheme},
-    setup_requires=["setuptools_scm"],
-    install_requires=[
-        "appdirs",
-        "httpx>=0.13,<0.19",
-        "pytablewriter[html]>=0.49",
-        "python-dateutil",
-        "python-slugify",
-    ],
-    extras_require={
-        "numpy": ["numpy"],
-        "pandas": ["pandas"],
-        "tests": ["freezegun", "pytest", "pytest-cov", "respx>=0.11"],
-    },
-    python_requires=">=3.6",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "Intended Audience :: End Users/Desktop",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: Implementation :: CPython",
-    ],
 )


### PR DESCRIPTION
Converted using https://github.com/asottile/setup-py-upgrade. First this happened:

```console
$ setup-py-upgrade .
use_scm_version= is not supported in setup.cfg
```

So temporarily removed that line from `setup.py` and re-ran it:

```console
$ setup-py-upgrade .
./setup.py and ./setup.cfg written!
```

Then reinstated `use_scm_version=` and `local_scheme(version)` in `setup.py`.

---

Also add https://github.com/asottile/setup-cfg-fmt to pre-commit and autoupdate.
