### PR TITLE
Docs: Travis CI has been replaced with GHA

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 Hugo van Kemenade
+Copyright (c) 2018-2021 Hugo van Kemenade
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![PyPI version](https://img.shields.io/pypi/v/pypistats.svg?logo=pypi&logoColor=FFE873)](https://pypi.org/project/pypistats/)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/pypistats.svg?logo=python&logoColor=FFE873)](https://pypi.org/project/pypistats/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/pypistats.svg)](https://pypistats.org/packages/pypistats)
-[![Travis CI status](https://img.shields.io/travis/hugovk/pypistats/master?label=Travis%20CI&logo=travis)](https://travis-ci.org/hugovk/pypistats)
 [![Azure Pipelines status](https://dev.azure.com/hugovk/hugovk/_apis/build/status/hugovk.pypistats?branchName=master)](https://dev.azure.com/hugovk/hugovk/_build?definitionId=1)
 [![GitHub Actions status](https://github.com/hugovk/pypistats/workflows/Test/badge.svg)](https://github.com/hugovk/pypistats/actions)
 [![codecov](https://codecov.io/gh/hugovk/pypistats/branch/master/graph/badge.svg)](https://codecov.io/gh/hugovk/pypistats)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,8 @@
 # Release Checklist
 
 - [ ] Get master to the appropriate code release state.
-      [Travis CI](https://travis-ci.org/hugovk/pypistats) and
       [GitHub Actions](https://github.com/hugovk/pypistats/actions) should be running
       cleanly for all merges to master.
-      [![Build Status](https://travis-ci.org/hugovk/pypistats.svg?branch=master)](https://travis-ci.org/hugovk/pypistats)
       [![GitHub Actions status](https://github.com/hugovk/pypistats/workflows/Test/badge.svg)](https://github.com/hugovk/pypistats/actions)
 
 - [ ] Edit release draft, adjust text if needed:
@@ -14,8 +12,9 @@
 
 - [ ] Publish release
 
-- [ ] Check the tagged [Travis CI build](https://travis-ci.org/hugovk/pypistats) has
-      deployed to [PyPI](https://pypi.org/project/pypistats/#history)
+- [ ] Check the tagged
+      [GitHub Actions build](https://github.com/hugovk/pypistats/actions/workflows/deploy.yml)
+      has deployed to [PyPI](https://pypi.org/project/pypistats/#history)
 
 - [ ] Check installation:
 


### PR DESCRIPTION
Travis CI was ditched in https://github.com/hugovk/pypistats/pull/192.