### PR TITLE
Test on Python 3.10.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,9 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.17.0
+    rev: v1.18.0
     hooks:
       - id: setup-cfg-fmt
-        args: ["--max-py-version", "3.10"]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.4.1


### PR DESCRIPTION
Released yesterday.

https://discuss.python.org/t/python-3-10-0-is-now-available/10955

Cannot remove the py310 special case in tox.ini yet, waiting for NumPy and Pandas wheels for macOS and Windows.

https://github.com/hugovk/pypistats/runs/3801157766?check_suite_focus=true

Also need to wait for Azure Pipelines to include 3.10 in their images next week.