### PR TITLE
Drop Python 3.6 and add some type hints

### DIFF
--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -9,8 +9,6 @@ jobs:
 
     strategy:
       matrix:
-        Python36:
-          python.version: "3.6"
         Python37:
           python.version: "3.7"
         Python38:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,18 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: deploy-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            deploy-
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,21 +26,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-v2-${{
-            hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-v2-
+          cache: pip
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,14 +49,8 @@ jobs:
           python -m pip install -U tox
 
       - name: Tox tests
-        if: matrix.python-version != '3.10'
         run: |
           tox -e py
-
-      - name: Tox tests (3.10)
-        if: matrix.python-version == '3.10'
-        run: |
-          tox -e py310
 
       - name: Tox tests (pins)
         if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,6 @@ repos:
     hooks:
       - id: black
         args: ["--target-version", "py36"]
-        # override until resolved: https://github.com/psf/black/issues/402
-        files: \.pyi?$
-        types: []
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.9.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     rev: v2.29.0
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: [--py37-plus]
 
   - repo: https://github.com/psf/black
     rev: 21.9b0
     hooks:
       - id: black
-        args: ["--target-version", "py36"]
+        args: [--target-version=py37]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.9.3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![DOI](https://zenodo.org/badge/149862343.svg)](https://zenodo.org/badge/latestdoi/149862343)
 [![Code style: Black](https://img.shields.io/badge/code%20style-Black-000000.svg)](https://github.com/psf/black)
 
-Python 3.6+ interface to [PyPI Stats API](https://pypistats.org/api) to get aggregate
+Python interface to [PyPI Stats API](https://pypistats.org/api) to get aggregate
 download statistics on Python packages on the Python Package Index without having to
 execute queries directly against Google BigQuery.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@ requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target_version = ["py36"]
+target_version = ["py37"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -40,7 +39,7 @@ install_requires =
     python-dateutil
     python-slugify
     importlib-metadata;python_version < '3.8'
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir = =src
 setup_requires =
     setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-def local_scheme(version):
+def local_scheme(version) -> str:
     """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
     to be able to upload to Test PyPI"""
     return ""

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -3,6 +3,8 @@
 Python interface to PyPI Stats API
 https://pypistats.org/api
 """
+from __future__ import annotations
+
 import atexit
 import datetime as dt
 import json
@@ -27,18 +29,18 @@ CACHE_DIR = Path(user_cache_dir("pypistats"))
 USER_AGENT = f"pypistats/{__version__}"
 
 
-def _print_verbose(verbose, *args, **kwargs):
+def _print_verbose(verbose: bool, *args, **kwargs) -> None:
     """Print if verbose"""
     if verbose:
         _print_stderr(*args, **kwargs)
 
 
-def _print_stderr(*args, **kwargs):
+def _print_stderr(*args, **kwargs) -> None:
     """Print to stderr"""
     print(*args, file=sys.stderr, **kwargs)
 
 
-def _cache_filename(url):
+def _cache_filename(url: str) -> Path:
     """yyyy-mm-dd-url-slug.json"""
     today = dt.datetime.utcnow().strftime("%Y-%m-%d")
     slug = slugify(url)
@@ -47,7 +49,7 @@ def _cache_filename(url):
     return filename
 
 
-def _load_cache(cache_file):
+def _load_cache(cache_file: Path) -> dict:
     if not cache_file.exists():
         return {}
 
@@ -60,7 +62,7 @@ def _load_cache(cache_file):
     return data
 
 
-def _save_cache(cache_file, data):
+def _save_cache(cache_file: Path, data) -> None:
     try:
         if not CACHE_DIR.exists():
             CACHE_DIR.mkdir(parents=True)
@@ -72,7 +74,7 @@ def _save_cache(cache_file, data):
         pass
 
 
-def _clear_cache():
+def _clear_cache() -> None:
     """Delete old cache files, run as last task"""
     cache_files = CACHE_DIR.glob("**/*.json")
     this_month = dt.datetime.utcnow().strftime("%Y-%m")
@@ -85,14 +87,14 @@ atexit.register(_clear_cache)
 
 
 def pypi_stats_api(
-    endpoint,
-    params=None,
-    format="markdown",
-    start_date=None,
-    end_date=None,
-    sort=True,
-    total="all",
-    verbose=False,
+    endpoint: str,
+    params: str | None = None,
+    format: str = "markdown",
+    start_date: str | None = None,
+    end_date: str | None = None,
+    sort: bool = True,
+    total: str = "all",
+    verbose: bool = False,
 ):
     """Call the API and return JSON"""
     if params:
@@ -195,7 +197,7 @@ def _filter(data, start_date=None, end_date=None):
     return data
 
 
-def _sort(data):
+def _sort(data: dict | list) -> dict | list:
     """Sort by downloads"""
 
     # Only for lists of dicts, not a single dict
@@ -206,7 +208,7 @@ def _sort(data):
     return data
 
 
-def _monthly_total(data):
+def _monthly_total(data: list) -> list:
     """Sum all downloads per category, by month"""
 
     totalled = {}
@@ -231,7 +233,7 @@ def _monthly_total(data):
     return data
 
 
-def _total(data):
+def _total(data: dict | list) -> dict | list:
     """Sum all downloads per category, regardless of date"""
 
     # Only for lists of dicts, not a single dict
@@ -252,7 +254,7 @@ def _total(data):
     return data
 
 
-def _date_range(data):
+def _date_range(data: dict | list) -> tuple[str | None, str | None]:
     """Return the first and last dates in data"""
     try:
         first = data[0]["date"]
@@ -270,7 +272,7 @@ def _date_range(data):
     return first, last
 
 
-def _grand_total_value(data):
+def _grand_total_value(data: list) -> int:
     """Return the grand total of the data"""
 
     # For "overall", without_mirrors is a subset of with_mirrors.
@@ -285,7 +287,7 @@ def _grand_total_value(data):
     return grand_total
 
 
-def _grand_total(data):
+def _grand_total(data: dict | list) -> dict | list:
     """Add a grand total row"""
 
     # Only for lists of dicts, not a single dict
@@ -304,7 +306,7 @@ def _grand_total(data):
     return data
 
 
-def _percent(data):
+def _percent(data: dict | list) -> dict | list:
     """Add a percent column"""
 
     # Only for lists of dicts, not a single dict
@@ -323,7 +325,7 @@ def _percent(data):
     return data
 
 
-def _tabulate(data, format: str = "markdown"):
+def _tabulate(data: dict | list, format: str = "markdown"):
     """Return data in specified format"""
 
     if isinstance(data, dict):
@@ -428,7 +430,7 @@ def _pytablewriter(headers, data, format: str):
     return writer.dumps()
 
 
-def _paramify(param_name, param_value):
+def _paramify(param_name: str, param_value: float | str | None) -> str:
     """If param_value, return &param_name=param_value"""
     if isinstance(param_value, bool):
         param_value = str(param_value).lower()
@@ -439,14 +441,14 @@ def _paramify(param_name, param_value):
     return ""
 
 
-def recent(package, period=None, **kwargs):
+def recent(package: str, period: str | None = None, **kwargs: str):
     """Retrieve the aggregate download quantities for the last day/week/month"""
     endpoint = f"packages/{package}/recent"
     params = _paramify("period", period)
     return pypi_stats_api(endpoint, params, **kwargs)
 
 
-def overall(package, mirrors=None, **kwargs):
+def overall(package: str, mirrors: bool | str | None = None, **kwargs: str):
     """Retrieve the aggregate daily download time series with or without mirror
     downloads"""
     endpoint = f"packages/{package}/overall"
@@ -454,7 +456,7 @@ def overall(package, mirrors=None, **kwargs):
     return pypi_stats_api(endpoint, params, **kwargs)
 
 
-def python_major(package, version=None, **kwargs):
+def python_major(package: str, version: str | None = None, **kwargs: str):
     """Retrieve the aggregate daily download time series by Python major version
     number"""
     endpoint = f"packages/{package}/python_major"
@@ -462,7 +464,7 @@ def python_major(package, version=None, **kwargs):
     return pypi_stats_api(endpoint, params, **kwargs)
 
 
-def python_minor(package, version=None, **kwargs):
+def python_minor(package: str, version: str | None = None, **kwargs) -> str:
     """Retrieve the aggregate daily download time series by Python minor version
     number"""
     endpoint = f"packages/{package}/python_minor"
@@ -470,7 +472,7 @@ def python_minor(package, version=None, **kwargs):
     return pypi_stats_api(endpoint, params, **kwargs)
 
 
-def system(package, os=None, **kwargs):
+def system(package: str, os: str | None = None, **kwargs):
     """Retrieve the aggregate daily download time series by operating system"""
     endpoint = f"packages/{package}/system"
     params = _paramify("os", os)

--- a/src/pypistats/cli.py
+++ b/src/pypistats/cli.py
@@ -2,6 +2,8 @@
 """
 CLI with subcommands for pypistats
 """
+from __future__ import annotations
+
 import argparse
 import datetime as dt
 
@@ -58,7 +60,7 @@ def subcommand(args=None, parent=subparsers):
     return decorator
 
 
-def _month_name_to_yyyy_mm(date_string, date_format):
+def _month_name_to_yyyy_mm(date_string: str, date_format: str) -> str:
     """Given a month name, return yyyy-dd for the most recent month in the past"""
     today = dt.date.today()
     new = dt.datetime.strptime(
@@ -73,7 +75,7 @@ def _month_name_to_yyyy_mm(date_string, date_format):
     return new.isoformat()[:7]
 
 
-def _valid_date(date_string, date_format):
+def _valid_date(date_string: str, date_format: str) -> str:
     try:
         dt.datetime.strptime(date_string, date_format)
         return date_string
@@ -82,11 +84,11 @@ def _valid_date(date_string, date_format):
         raise argparse.ArgumentTypeError(msg)
 
 
-def _valid_yyyy_mm_dd(date_string):
+def _valid_yyyy_mm_dd(date_string: str) -> str:
     return _valid_date(date_string, "%Y-%m-%d")
 
 
-def _valid_yyyy_mm(date_string):
+def _valid_yyyy_mm(date_string: str) -> str:
     try:
         # eg. jan, feb
         date_string = _month_name_to_yyyy_mm(date_string, "%b")
@@ -102,14 +104,14 @@ def _valid_yyyy_mm(date_string):
     return _valid_date(date_string, "%Y-%m")
 
 
-def _valid_yyyy_mm_optional_dd(date_string):
+def _valid_yyyy_mm_optional_dd(date_string: str) -> str:
     try:
         return _valid_yyyy_mm_dd(date_string)
     except argparse.ArgumentTypeError:
         return _valid_yyyy_mm(date_string)
 
 
-def _define_format(args) -> str:
+def _define_format(args: argparse.Namespace) -> str:
     if args.json:
         return "json"
 
@@ -182,7 +184,7 @@ common_arguments = [
         arg_verbose,
     ]
 )
-def recent(args):  # pragma: no cover
+def recent(args: argparse.Namespace) -> None:  # pragma: no cover
     print(
         pypistats.recent(
             args.package, period=args.period, format=args.format, verbose=args.verbose
@@ -197,7 +199,7 @@ def recent(args):  # pragma: no cover
         *common_arguments,
     ]
 )
-def overall(args):  # pragma: no cover
+def overall(args: argparse.Namespace) -> None:  # pragma: no cover
     if args.mirrors in ["with", "without"]:
         args.mirrors = args.mirrors == "with"
 
@@ -221,7 +223,7 @@ def overall(args):  # pragma: no cover
         *common_arguments,
     ]
 )
-def python_major(args):  # pragma: no cover
+def python_major(args: argparse.Namespace) -> None:  # pragma: no cover
     print(
         pypistats.python_major(
             args.package,
@@ -242,7 +244,7 @@ def python_major(args):  # pragma: no cover
         *common_arguments,
     ]
 )
-def python_minor(args):  # pragma: no cover
+def python_minor(args: argparse.Namespace) -> None:  # pragma: no cover
     print(
         pypistats.python_minor(
             args.package,
@@ -263,7 +265,7 @@ def python_minor(args):  # pragma: no cover
         *common_arguments,
     ]
 )
-def system(args):  # pragma: no cover
+def system(args: argparse.Namespace) -> None:  # pragma: no cover
     print(
         pypistats.system(
             args.package,
@@ -277,7 +279,7 @@ def system(args):  # pragma: no cover
     )
 
 
-def _month(yyyy_mm):
+def _month(yyyy_mm: str) -> tuple[str, str]:
     """Helper to return start_date and end_date of a month as yyyy-mm-dd"""
     year, month = map(int, yyyy_mm.split("-"))
     first = dt.date(year, month, 1)
@@ -285,21 +287,21 @@ def _month(yyyy_mm):
     return str(first), str(last)
 
 
-def _last_month():
+def _last_month() -> tuple[str, str]:
     """Helper to return start_date and end_date of the previous month as yyyy-mm-dd"""
     today = dt.date.today()
     d = today - relativedelta(months=1)
     return _month(d.isoformat()[:7])
 
 
-def _this_month():
+def _this_month() -> str:
     """Helper to return start_date of the current month as yyyy-mm-dd.
     No end_date needed."""
     today = dt.date.today()
     return _month(today.isoformat()[:7])[0]
 
 
-def main():
+def main() -> None:
     cli.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {pypistats.__version__}"
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ from pypistats import cli
         ("2018-12", ("2018-12-01", "2018-12-31")),
     ],
 )
-def test__month(test_input, expected):
+def test__month(test_input: str, expected: str) -> None:
     # Act
     first, last = cli._month(test_input)
 
@@ -32,7 +32,7 @@ def test__month(test_input, expected):
         ("2018-12-25", ("2018-11-01", "2018-11-30")),
     ],
 )
-def test__last_month(test_input, expected):
+def test__last_month(test_input: str, expected: str) -> None:
     # Act
     with freeze_time(test_input):
         first, last = cli._last_month()
@@ -49,7 +49,7 @@ def test__last_month(test_input, expected):
         ("2019-12-25", "2019-12-01"),
     ],
 )
-def test__this_month(test_input, expected):
+def test__this_month(test_input: str, expected: str) -> None:
     # Act
     with freeze_time(test_input):
         first = cli._this_month()
@@ -73,7 +73,7 @@ def test__this_month(test_input, expected):
         ("december", "%B", "2018-12"),
     ],
 )
-def test__month_name_to_yyyy_mm(name, date_format, expected):
+def test__month_name_to_yyyy_mm(name: str, date_format: str, expected: str) -> None:
     # Act
     output = cli._month_name_to_yyyy_mm(name, date_format)
 
@@ -82,18 +82,18 @@ def test__month_name_to_yyyy_mm(name, date_format, expected):
 
 
 @pytest.mark.parametrize("test_input", ["2018-01-12", "2018-07-12", "2018-12-12"])
-def test__valid_yyyy_mm_dd_valid(test_input):
+def test__valid_yyyy_mm_dd_valid(test_input: str) -> None:
     assert test_input == cli._valid_yyyy_mm_dd(test_input)
 
 
 @pytest.mark.parametrize("test_input", ["asdfsdssd", "2018-99-99", "2018-xx"])
-def test__valid_yyyy_mm_dd_invalid(test_input):
+def test__valid_yyyy_mm_dd_invalid(test_input: str) -> None:
     with pytest.raises(argparse.ArgumentTypeError):
         cli._valid_yyyy_mm_dd(test_input)
 
 
 @pytest.mark.parametrize("test_input", ["2018-01", "2018-07", "2018-12"])
-def test__valid_yyyy_mm_valid(test_input):
+def test__valid_yyyy_mm_valid(test_input: str) -> None:
     assert test_input == cli._valid_yyyy_mm(test_input)
 
 
@@ -112,18 +112,18 @@ def test__valid_yyyy_mm_valid(test_input):
         ("december", "2018-12"),
     ],
 )
-def test__valid_yyyy_mm_valid_name(test_input, expected):
+def test__valid_yyyy_mm_valid_name(test_input: str, expected: str) -> None:
     assert expected == cli._valid_yyyy_mm(test_input)
 
 
 @pytest.mark.parametrize("test_input", ["dfkgjskfjgk", "2018-99", "2018-xx"])
-def test__valid_yyyy_mm_invalid(test_input):
+def test__valid_yyyy_mm_invalid(test_input: str) -> None:
     with pytest.raises(argparse.ArgumentTypeError):
         cli._valid_yyyy_mm(test_input)
 
 
 @pytest.mark.parametrize("test_input", ["2019-01-21", "2019-01"])
-def test__valid_yyyy_mm_optional_dd_valid(test_input):
+def test__valid_yyyy_mm_optional_dd_valid(test_input: str) -> None:
     assert test_input == cli._valid_yyyy_mm_optional_dd(test_input)
 
 
@@ -131,24 +131,24 @@ def test__valid_yyyy_mm_optional_dd_valid(test_input):
 @pytest.mark.parametrize(
     "test_input, expected", [("jan", "2019-01"), ("february", "2019-02")]
 )
-def test__valid_yyyy_mm_optional_dd_valid_name(test_input, expected):
+def test__valid_yyyy_mm_optional_dd_valid_name(test_input: str, expected: str) -> None:
     assert expected == cli._valid_yyyy_mm_optional_dd(test_input)
 
 
 @pytest.mark.parametrize("test_input", ["dkvnf", "2018-99", "2018-xx"])
-def test__valid_yyyy_mm_optional_dd_invalid(test_input):
+def test__valid_yyyy_mm_optional_dd_invalid(test_input: str) -> None:
     with pytest.raises(argparse.ArgumentTypeError):
         cli._valid_yyyy_mm_optional_dd(test_input)
 
 
 class __Args:
-    def __init__(self):
+    def __init__(self) -> None:
         self.json = False  # type: bool
         self.format = "markdown"  # type: str
 
 
 @pytest.mark.parametrize("test_input, expected", [(False, "markdown"), (True, "json")])
-def test__define_format_json_flag(test_input, expected):
+def test__define_format_json_flag(test_input: bool, expected: str) -> None:
     # Arrange
     args = __Args()
     args.json = test_input
@@ -161,7 +161,7 @@ def test__define_format_json_flag(test_input, expected):
 
 
 @pytest.mark.parametrize("test_input", ["json", "markdown"])
-def test__define_format_format_flag(test_input):
+def test__define_format_format_flag(test_input: str) -> None:
     # Arrange
     args = __Args()
     args.json = False

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -62,28 +62,28 @@ SAMPLE_RESPONSE_OVERALL = """{
         }"""
 
 
-def stub__cache_filename(*args):
+def stub__cache_filename(*args) -> Path:
     return Path("/this/does/not/exist")
 
 
-def stub__save_cache(*args):
+def stub__save_cache(*args) -> None:
     pass
 
 
 class TestPypiStats:
-    def setup_method(self):
+    def setup_method(self) -> None:
         # Stub caching. Caches are tested in another class.
         self.original__cache_filename = pypistats._cache_filename
         self.original__save_cache = pypistats._save_cache
         pypistats._cache_filename = stub__cache_filename
         pypistats._save_cache = stub__save_cache
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         # Unstub caching
         pypistats._cache_filename = self.original__cache_filename
         pypistats._save_cache = self.original__save_cache
 
-    def test__filter_no_filters_no_change(self):
+    def test__filter_no_filters_no_change(self) -> None:
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)
 
@@ -93,7 +93,7 @@ class TestPypiStats:
         # Assert
         assert data == output
 
-    def test__filter_start_date(self):
+    def test__filter_start_date(self) -> None:
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)
         start_date = "2018-09-22"
@@ -106,7 +106,7 @@ class TestPypiStats:
         for row in output:
             assert row["date"] >= start_date
 
-    def test__filter_end_date(self):
+    def test__filter_end_date(self) -> None:
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)
         end_date = "2018-04-22"
@@ -119,7 +119,7 @@ class TestPypiStats:
         for row in output:
             assert row["date"] <= end_date
 
-    def test__filter_start_and_end_date(self):
+    def test__filter_start_and_end_date(self) -> None:
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)
         start_date = "2018-09-01"
@@ -135,7 +135,7 @@ class TestPypiStats:
             assert row["date"] <= end_date
 
     @respx.mock
-    def test_warn_if_start_date_before_earliest_available(self):
+    def test_warn_if_start_date_before_earliest_available(self) -> None:
         # Arrange
         start_date = "2000-01-01"
         package = "pip"
@@ -161,7 +161,7 @@ class TestPypiStats:
             pypistats.python_major(package, start_date=start_date)
 
     @respx.mock
-    def test_error_if_end_date_before_earliest_available(self):
+    def test_error_if_end_date_before_earliest_available(self) -> None:
         # Arrange
         end_date = "2000-01-01"
         package = "pip"
@@ -186,7 +186,7 @@ class TestPypiStats:
         ):
             pypistats.python_major(package, end_date=end_date)
 
-    def test__paramify_none(self):
+    def test__paramify_none(self) -> None:
         # Arrange
         period = None
 
@@ -196,7 +196,7 @@ class TestPypiStats:
         # Assert
         assert param == ""
 
-    def test__paramify_string(self):
+    def test__paramify_string(self) -> None:
         # Arrange
         period = "day"
 
@@ -206,7 +206,7 @@ class TestPypiStats:
         # Assert
         assert param == "&period=day"
 
-    def test__paramify_bool(self):
+    def test__paramify_bool(self) -> None:
         # Arrange
         mirrors = True
 
@@ -216,7 +216,7 @@ class TestPypiStats:
         # Assert
         assert param == "&mirrors=true"
 
-    def test__paramify_int(self):
+    def test__paramify_int(self) -> None:
         # Arrange
         version = 3
 
@@ -226,7 +226,7 @@ class TestPypiStats:
         # Assert
         assert param == "&version=3"
 
-    def test__paramify_float(self):
+    def test__paramify_float(self) -> None:
         # Arrange
         version = 3.7
 
@@ -236,7 +236,7 @@ class TestPypiStats:
         # Assert
         assert param == "&version=3.7"
 
-    def test__tabulate_noarg(self):
+    def test__tabulate_noarg(self) -> None:
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA)
         expected_output = EXPECTED_TABULATED_MD
@@ -256,7 +256,7 @@ class TestPypiStats:
             pytest.param("tsv", EXPECTED_TABULATED_TSV, id="tsv"),
         ],
     )
-    def test__tabulate(self, test_input, expected):
+    def test__tabulate(self, test_input: str, expected: str) -> None:
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA)
 
@@ -266,7 +266,7 @@ class TestPypiStats:
         # Assert
         assert output.strip() == expected.strip()
 
-    def test__sort(self):
+    def test__sort(self) -> None:
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA)
         expected_output = [
@@ -288,7 +288,7 @@ class TestPypiStats:
         # Assert
         assert output == expected_output
 
-    def test__sort_recent(self):
+    def test__sort_recent(self) -> None:
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA_RECENT)
 
@@ -298,7 +298,7 @@ class TestPypiStats:
         # Assert
         assert output == SAMPLE_DATA_RECENT
 
-    def test__monthly_total(self):
+    def test__monthly_total(self) -> None:
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)
 
@@ -316,7 +316,7 @@ class TestPypiStats:
         assert output[10]["downloads"] == 489_163
         assert output[10]["date"] == "2018-05"
 
-    def test__total(self):
+    def test__total(self) -> None:
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)
 
@@ -328,7 +328,7 @@ class TestPypiStats:
         assert output[0]["category"] == "2.4"
         assert output[0]["downloads"] == 9
 
-    def test__total_recent(self):
+    def test__total_recent(self) -> None:
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA_RECENT)
 
@@ -338,7 +338,7 @@ class TestPypiStats:
         # Assert
         assert output == SAMPLE_DATA_RECENT
 
-    def test__date_range(self):
+    def test__date_range(self) -> None:
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)
 
@@ -349,7 +349,7 @@ class TestPypiStats:
         assert first == "2018-04-16"
         assert last == "2018-09-23"
 
-    def test__date_range_no_dates_in_data(self):
+    def test__date_range_no_dates_in_data(self) -> None:
         # Arrange
         # recent
         data = [
@@ -367,7 +367,7 @@ class TestPypiStats:
         assert first is None
         assert last is None
 
-    def test__grand_total(self):
+    def test__grand_total(self) -> None:
         # Arrange
         data = copy.deepcopy(PYTHON_MINOR_DATA)
         original_len = len(data)
@@ -380,7 +380,7 @@ class TestPypiStats:
         assert output[-1]["category"] == "Total"
         assert output[-1]["downloads"] == 9_355_317
 
-    def test__grand_total_one_row(self):
+    def test__grand_total_one_row(self) -> None:
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA_ONE_ROW)
 
@@ -390,7 +390,7 @@ class TestPypiStats:
         # Assert
         assert output == SAMPLE_DATA_ONE_ROW
 
-    def test__grand_total_recent(self):
+    def test__grand_total_recent(self) -> None:
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA_RECENT)
 
@@ -400,7 +400,7 @@ class TestPypiStats:
         # Assert
         assert output == SAMPLE_DATA_RECENT
 
-    def test__percent(self):
+    def test__percent(self) -> None:
         # Arrange
         data = [
             {"category": "2.7", "downloads": 63749},
@@ -421,7 +421,7 @@ class TestPypiStats:
         # Assert
         assert output == expected_output
 
-    def test__percent_one_row(self):
+    def test__percent_one_row(self) -> None:
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA_ONE_ROW)
 
@@ -431,7 +431,7 @@ class TestPypiStats:
         # Assert
         assert output == SAMPLE_DATA_ONE_ROW
 
-    def test__percent_recent(self):
+    def test__percent_recent(self) -> None:
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA_RECENT)
 
@@ -442,7 +442,7 @@ class TestPypiStats:
         assert output == SAMPLE_DATA_RECENT
 
     @respx.mock
-    def test_valid_json(self):
+    def test_valid_json(self) -> None:
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/recent?&period=day"
@@ -482,7 +482,7 @@ class TestPypiStats:
             ),
         ],
     )
-    def test_recent_tabular(self, test_format, expected_output):
+    def test_recent_tabular(self, test_format, expected_output) -> None:
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/recent"
@@ -500,7 +500,7 @@ class TestPypiStats:
         assert output.strip() == expected_output.strip()
 
     @respx.mock
-    def test_overall_tabular_start_date(self):
+    def test_overall_tabular_start_date(self) -> None:
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/overall?&mirrors=false"
@@ -523,7 +523,7 @@ Date range: 2020-05-02 - 2020-05-02
         assert output.strip() == expected_output.strip()
 
     @respx.mock
-    def test_overall_tabular_end_date(self):
+    def test_overall_tabular_end_date(self) -> None:
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/overall?&mirrors=false"
@@ -546,7 +546,7 @@ Date range: 2020-05-01 - 2020-05-01
         assert output.strip() == expected_output.strip()
 
     @respx.mock
-    def test_python_major_json(self):
+    def test_python_major_json(self) -> None:
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/python_major"
@@ -577,7 +577,7 @@ Date range: 2020-05-01 - 2020-05-01
         assert json.loads(output) == json.loads(expected_output)
 
     @respx.mock
-    def test_python_minor_json(self):
+    def test_python_minor_json(self) -> None:
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/python_minor"
@@ -622,7 +622,7 @@ Date range: 2020-05-01 - 2020-05-01
         assert json.loads(output) == json.loads(expected_output)
 
     @respx.mock
-    def test_system_tabular(self):
+    def test_system_tabular(self) -> None:
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/system"
@@ -656,7 +656,7 @@ Date range: 2020-05-01 - 2020-05-01
         assert output.strip() == expected_output.strip()
 
     @respx.mock
-    def test_python_minor_monthly(self):
+    def test_python_minor_monthly(self) -> None:
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/python_minor"
@@ -693,7 +693,7 @@ Date range: 2020-05-01 - 2020-05-01
         assert json.loads(output) == json.loads(expected_output)
 
     @respx.mock
-    def test_versions_are_strings(self):
+    def test_versions_are_strings(self) -> None:
         # Arrange
         data = copy.deepcopy(SAMPLE_DATA_VERSION_STRINGS)
         expected_output = """
@@ -711,7 +711,7 @@ Date range: 2020-05-01 - 2020-05-01
 
     @pytest.mark.skipif(numpy is None, reason="NumPy is not installed")
     @respx.mock
-    def test_format_numpy(self):
+    def test_format_numpy(self) -> None:
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/overall"
@@ -732,7 +732,7 @@ Date range: 2020-05-01 - 2020-05-01
 
     @pytest.mark.skipif(pandas is None, reason="pandas is not installed")
     @respx.mock
-    def test_format_pandas(self):
+    def test_format_pandas(self) -> None:
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/overall"

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -186,55 +186,22 @@ class TestPypiStats:
         ):
             pypistats.python_major(package, end_date=end_date)
 
-    def test__paramify_none(self) -> None:
-        # Arrange
-        period = None
-
+    @pytest.mark.parametrize(
+        "test_name, test_value, expected",
+        [
+            ("period", None, ""),
+            ("period", "day", "&period=day"),
+            ("mirrors", True, "&mirrors=true"),
+            ("version", 3, "&version=3"),
+            ("version", 3.7, "&version=3.7"),
+        ],
+    )
+    def test__paramify(self, test_name, test_value, expected) -> None:
         # Act
-        param = pypistats._paramify("period", period)
+        param = pypistats._paramify(test_name, test_value)
 
         # Assert
-        assert param == ""
-
-    def test__paramify_string(self) -> None:
-        # Arrange
-        period = "day"
-
-        # Act
-        param = pypistats._paramify("period", period)
-
-        # Assert
-        assert param == "&period=day"
-
-    def test__paramify_bool(self) -> None:
-        # Arrange
-        mirrors = True
-
-        # Act
-        param = pypistats._paramify("mirrors", mirrors)
-
-        # Assert
-        assert param == "&mirrors=true"
-
-    def test__paramify_int(self) -> None:
-        # Arrange
-        version = 3
-
-        # Act
-        param = pypistats._paramify("version", version)
-
-        # Assert
-        assert param == "&version=3"
-
-    def test__paramify_float(self) -> None:
-        # Arrange
-        version = 3.7
-
-        # Act
-        param = pypistats._paramify("version", version)
-
-        # Assert
-        assert param == "&version=3.7"
+        assert param == expected
 
     def test__tabulate_noarg(self) -> None:
         # Arrange

--- a/tests/test_pypistats_cache.py
+++ b/tests/test_pypistats_cache.py
@@ -11,18 +11,18 @@ import pypistats
 
 
 class TestPypiStatsCache:
-    def setup_method(self):
+    def setup_method(self) -> None:
         # Choose a new cache dir that doesn't exist
         self.original_cache_dir = pypistats.CACHE_DIR
         self.temp_dir = tempfile.TemporaryDirectory()
         pypistats.CACHE_DIR = Path(self.temp_dir.name) / "pypistats"
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         # Reset original
         pypistats.CACHE_DIR = self.original_cache_dir
 
     @freeze_time("2018-12-26")
-    def test__cache_filename(self):
+    def test__cache_filename(self) -> None:
         # Arrange
         url = "https://pypistats.org/api/packages/pip/recent"
 
@@ -34,7 +34,7 @@ class TestPypiStatsCache:
             "2018-12-26-https-pypistats-org-api-packages-pip-recent.json"
         )
 
-    def test__load_cache_not_exist(self):
+    def test__load_cache_not_exist(self) -> None:
         # Arrange
         filename = Path("file-does-not-exist")
 
@@ -44,7 +44,7 @@ class TestPypiStatsCache:
         # Assert
         assert data == {}
 
-    def test__load_cache_bad_data(self):
+    def test__load_cache_bad_data(self) -> None:
         # Arrange
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write(b"Invalid JSON!")
@@ -55,7 +55,7 @@ class TestPypiStatsCache:
         # Assert
         assert data == {}
 
-    def test_cache_round_trip(self):
+    def test_cache_round_trip(self) -> None:
         # Arrange
         filename = pypistats.CACHE_DIR / "test_cache_round_trip.json"
         data = "test data"
@@ -70,7 +70,7 @@ class TestPypiStatsCache:
         # Assert
         assert new_data == data
 
-    def test__clear_cache(self):
+    def test__clear_cache(self) -> None:
         # Arrange
         # Create old cache file
         cache_file = pypistats.CACHE_DIR / "2018-11-26-old-cache-file.json"
@@ -84,7 +84,7 @@ class TestPypiStatsCache:
         assert not cache_file.exists()
 
     @respx.mock
-    def test_subcommand_with_cache(self):
+    def test_subcommand_with_cache(self) -> None:
         # Arrange
         package = "pip"
         mocked_url = "https://pypistats.org/api/packages/pip/overall"

--- a/tests/test_pypistats_print.py
+++ b/tests/test_pypistats_print.py
@@ -2,7 +2,7 @@ import pypistats
 
 
 # pytest's capsys cannot be used in a unittest class
-def test__print_verbose_print(capsys):
+def test__print_verbose_print(capsys) -> None:
     # Arrange
     verbose = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{36, 37, 38, 39, 310}
+    py{37, 38, 39, 310}
     pins
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -18,12 +18,6 @@ commands =
     pypistats --help
     pypistats recent --help
 
-[testenv:py310]
-extras =
-    tests
-commands_pre =
-    - {envpython} -m pip install --only-binary :all: numpy pandas
-
 [testenv:pins]
 extras = None
 commands_pre =


### PR DESCRIPTION
We need to drop 3.6 to use `from __future__ import annotations`. Could use 3.6 compatible things like `from typing import Tuple, Union`, but 3.6 is soon EOL:

| cycle | latest |  release   |    eol     |
|-------|--------|------------|------------|
| 3.10  | 3.10.0 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.7  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |

And has lowest of the (quite low anyway) pip installs from PyPI for September 2021:

| category | percent | downloads |
| -------- | ------: | --------: |
| 3.8      |  35.78% |       307 |
| 3.7      |  23.43% |       201 |
| null     |  20.40% |       175 |
| 3.9      |  12.94% |       111 |
| 3.6      |   7.46% |        64 |
| Total    |         |       858 |

Source: `pip install -U pypistats && pypistats python_minor pypistats --last-month`

Plus refactor some tests to use `pytest.mark.parametrize` and add `pytest.param(..., id=...)` to make nicer verbose output.