### PR TITLE
Add --color option

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,4 +41,8 @@ jobs:
           architecture: "x64"
 
       - script: python setup.py sdist
-        displayName: "Build sdist"
+      - script: |
+          python -m pip install --upgrade pip
+          python -m pip install -U build twine wheel
+          python -m build
+        displayName: "Build sdist and wheel"

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     pytablewriter[html]>=0.63
     python-dateutil
     python-slugify
+    termcolor
     importlib-metadata;python_version < '3.8'
 python_requires = >=3.7
 package_dir = =src

--- a/src/pypistats/cli.py
+++ b/src/pypistats/cli.py
@@ -156,6 +156,13 @@ arg_monthly = argument("--monthly", action="store_true", help="Show monthly down
 arg_format = argument(
     "-f", "--format", default="markdown", choices=FORMATS, help="The format of output"
 )
+arg_color = argument(
+    "-c",
+    "--color",
+    default="auto",
+    choices=("yes", "no", "auto"),
+    help="Color terminal output",
+)
 arg_verbose = argument(
     "-v", "--verbose", action="store_true", help="Print debug messages to stderr"
 )
@@ -171,6 +178,7 @@ common_arguments = [
     arg_this_month,
     arg_daily,
     arg_monthly,
+    arg_color,
     arg_verbose,
 ]
 
@@ -211,6 +219,7 @@ def overall(args: argparse.Namespace) -> None:  # pragma: no cover
             end_date=args.end_date,
             format=args.format,
             total="daily" if args.daily else ("monthly" if args.monthly else "all"),
+            color="no",  # Coloured percentages not really helpful here
             verbose=args.verbose,
         )
     )
@@ -232,6 +241,7 @@ def python_major(args: argparse.Namespace) -> None:  # pragma: no cover
             end_date=args.end_date,
             format=args.format,
             total="daily" if args.daily else ("monthly" if args.monthly else "all"),
+            color=args.color,
             verbose=args.verbose,
         )
     )
@@ -253,6 +263,7 @@ def python_minor(args: argparse.Namespace) -> None:  # pragma: no cover
             end_date=args.end_date,
             format=args.format,
             total="daily" if args.daily else ("monthly" if args.monthly else "all"),
+            color=args.color,
             verbose=args.verbose,
         )
     )
@@ -274,6 +285,7 @@ def system(args: argparse.Namespace) -> None:  # pragma: no cover
             end_date=args.end_date,
             format=args.format,
             total="daily" if args.daily else ("monthly" if args.monthly else "all"),
+            color=args.color,
             verbose=args.verbose,
         )
     )


### PR DESCRIPTION
Add this option to most of the subcommands, `python_major`, `python_minor` and `system`:
```
  -c {yes,no,auto}, --color {yes,no,auto}
                        Color terminal output (default: auto)
```
And colour the percentages as follows:

* red: 0% - 5%
* yellow: 6% - 15%
* green: 15% - 100%

![image](https://user-images.githubusercontent.com/1324225/142499264-aaeaf7a3-bf1f-4adc-8156-1c198f549f8c.png)

