### PR TITLE
Bump to 'Development Status :: 5 - Production/Stable' for 1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ author = hugovk
 license = MIT
 license_file = LICENSE.txt
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     Intended Audience :: End Users/Desktop
     License :: OSI Approved :: MIT License


### PR DESCRIPTION
* First release was October 2018: https://github.com/hugovk/pypistats/releases/tag/0.1.0

* 1.0.0 was released two days ago: https://github.com/hugovk/pypistats/releases/tag/1.0.0

