### PR TITLE
Remove Python 3.11 exception

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,14 +31,8 @@ jobs:
           python -m pip install -U tox
 
       - name: Tox tests
-        if: matrix.python-version != '3.11-dev'
         run: |
           tox -e py
-
-      - name: Tox tests (3.11-dev)
-        if: matrix.python-version == '3.11-dev'
-        run: |
-          tox -e py311
 
       - name: Tox tests (pins)
         if: matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'

--- a/tox.ini
+++ b/tox.ini
@@ -38,9 +38,3 @@ extras =
     None
 commands_pre =
     {envpython} -m pip install -r requirements.txt
-
-[testenv:py311]
-extras =
-    tests
-commands_pre =
-    - {envpython} -m pip install --only-binary :all: numpy pandas


### PR DESCRIPTION
NumPy and Pandas now have wheels for 3.11