### PR TITLE
termcolor now disables colour if not tty, so set FORCE_COLOR for colour tests

### DIFF
--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -215,7 +215,7 @@ class TestPypiStats:
         # Act / Assert
         assert pypistats._can_do_colour() is True
 
-    def test__colourify(self) -> None:
+    def test__colourify(self, monkeypatch) -> None:
         # Arrange
         data = [
             {"category": "2.7", "downloads": 1},
@@ -233,6 +233,7 @@ class TestPypiStats:
         ]
         data = pypistats._percent(data)
         data = pypistats._grand_total(data)
+        monkeypatch.setenv("FORCE_COLOR", "1")
 
         # Act
         output = pypistats._colourify(data)


### PR DESCRIPTION
Since https://github.com/termcolor/termcolor/releases/tag/2.1.0 and https://github.com/termcolor/termcolor/pull/25, we need to make sure colour is enabled for this test.

Fixes failures seen in https://github.com/hugovk/pypistats/pull/362, https://github.com/hugovk/pypistats/actions/runs/3368082211.