### PR TITLE
Rename `--format border` to `--format pretty`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Help for a subcommand:
 ```console
 $ pypistats recent --help
 usage: pypistats recent [-h] [-p {day,week,month}]
-                        [-f {border,html,json,md,markdown,rich,rst,tsv}] [-j]
+                        [-f {html,json,pretty,md,markdown,rich,rst,tsv}] [-j]
                         [-v]
                         package
 
@@ -81,8 +81,8 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -p {day,week,month}, --period {day,week,month}
-  -f {border,html,json,md,markdown,rich,rst,tsv}, --format {border,html,json,md,markdown,rich,rst,tsv}
-                        The format of output (default: border)
+  -f {html,json,pretty,md,markdown,rich,rst,tsv}, --format {html,json,pretty,md,markdown,rich,rst,tsv}
+                        The format of output (default: pretty)
   -j, --json            Shortcut for "-f json" (default: False)
   -v, --verbose         Print debug messages to stderr (default: False)
 ```
@@ -98,7 +98,7 @@ $ pypistats recent pillow
 ┌───────────┬────────────┬────────────┐
 │  last_day │ last_month │  last_week │
 ├───────────┼────────────┼────────────┤
-│ 1,706,880 │ 45,503,494 │ 10,409,358 │
+│ 1,740,674 │ 50,722,906 │ 11,471,253 │
 └───────────┴────────────┴────────────┘
 ```
 
@@ -111,7 +111,7 @@ Help for another subcommand:
 ```console
 $ pypistats python_minor --help
 usage: pypistats python_minor [-h] [-V VERSION]
-                              [-f {border,html,json,md,markdown,rich,rst,tsv}]
+                              [-f {html,json,pretty,md,markdown,rich,rst,tsv}]
                               [-j] [-sd yyyy-mm[-dd]|name]
                               [-ed yyyy-mm[-dd]|name] [-m yyyy-mm|name] [-l]
                               [-t] [-d] [--monthly] [-c {yes,no,auto}] [-v]
@@ -127,8 +127,8 @@ options:
   -h, --help            show this help message and exit
   -V VERSION, --version VERSION
                         eg. 2.7 or 3.6 (default: None)
-  -f {border,html,json,md,markdown,rich,rst,tsv}, --format {border,html,json,md,markdown,rich,rst,tsv}
-                        The format of output (default: border)
+  -f {html,json,pretty,md,markdown,rich,rst,tsv}, --format {html,json,pretty,md,markdown,rich,rst,tsv}
+                        The format of output (default: pretty)
   -j, --json            Shortcut for "-f json" (default: False)
   -sd yyyy-mm[-dd]|name, --start-date yyyy-mm[-dd]|name
                         Start date (default: None)
@@ -157,23 +157,24 @@ $ pypistats python_minor pillow --last-month
 ┌──────────┬─────────┬────────────┐
 │ category │ percent │  downloads │
 ├──────────┼─────────┼────────────┤
-│ 3.7      │  28.97% │ 13,683,717 │
-│ 3.8      │  24.85% │ 11,738,755 │
-│ 3.9      │  16.22% │  7,658,826 │
-│ 3.6      │  14.08% │  6,649,941 │
-│ null     │   8.93% │  4,216,479 │
-│ 3.10     │   4.78% │  2,258,742 │
-│ 2.7      │   1.09% │    515,126 │
-│ 3.5      │   1.07% │    503,174 │
-│ 3.4      │   0.01% │      4,315 │
-│ 3.11     │   0.01% │      3,477 │
-│ 3.3      │   0.00% │         97 │
-│ 3.12     │   0.00% │         17 │
-│ 3.2      │   0.00% │          3 │
-│ Total    │         │ 47,232,669 │
+│ 3.7      │  36.58% │ 18,620,128 │
+│ 3.8      │  22.17% │ 11,285,248 │
+│ 3.9      │  13.83% │  7,041,419 │
+│ 3.6      │  10.72% │  5,454,315 │
+│ null     │   7.39% │  3,761,767 │
+│ 3.10     │   6.41% │  3,263,885 │
+│ 3.11     │   1.16% │    589,792 │
+│ 2.7      │   0.89% │    451,041 │
+│ 3.5      │   0.83% │    422,741 │
+│ 3.12     │   0.01% │      3,089 │
+│ 3.4      │   0.00% │      2,483 │
+│ 3.3      │   0.00% │        251 │
+│ 3.2      │   0.00% │         95 │
+│ 2.6      │   0.00% │          1 │
+│ Total    │         │ 50,896,255 │
 └──────────┴─────────┴────────────┘
 
-Date range: 2022-06-01 - 2022-06-30
+Date range: 2022-11-01 - 2022-11-30
 ```
 
 <!-- [[[end]]] -->
@@ -184,22 +185,23 @@ You can format in Markdown, ready for pasting in GitHub issues and PRs:
 
 | category | percent |  downloads |
 | :------- | ------: | ---------: |
-| 3.7      |  28.97% | 13,683,717 |
-| 3.8      |  24.85% | 11,738,755 |
-| 3.9      |  16.22% |  7,658,826 |
-| 3.6      |  14.08% |  6,649,941 |
-| null     |   8.93% |  4,216,479 |
-| 3.10     |   4.78% |  2,258,742 |
-| 2.7      |   1.09% |    515,126 |
-| 3.5      |   1.07% |    503,174 |
-| 3.4      |   0.01% |      4,315 |
-| 3.11     |   0.01% |      3,477 |
-| 3.3      |   0.00% |         97 |
-| 3.12     |   0.00% |         17 |
-| 3.2      |   0.00% |          3 |
-| Total    |         | 47,232,669 |
+| 3.7      |  36.58% | 18,620,128 |
+| 3.8      |  22.17% | 11,285,248 |
+| 3.9      |  13.83% |  7,041,419 |
+| 3.6      |  10.72% |  5,454,315 |
+| null     |   7.39% |  3,761,767 |
+| 3.10     |   6.41% |  3,263,885 |
+| 3.11     |   1.16% |    589,792 |
+| 2.7      |   0.89% |    451,041 |
+| 3.5      |   0.83% |    422,741 |
+| 3.12     |   0.01% |      3,089 |
+| 3.4      |   0.00% |      2,483 |
+| 3.3      |   0.00% |        251 |
+| 3.2      |   0.00% |         95 |
+| 2.6      |   0.00% |          1 |
+| Total    |         | 50,896,255 |
 
-Date range: 2022-06-01 - 2022-06-30
+Date range: 2022-11-01 - 2022-11-30
 
 <!-- [[[end]]] -->
 

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -90,7 +90,7 @@ atexit.register(_clear_cache)
 def pypi_stats_api(
     endpoint: str,
     params: str | None = None,
-    format: str = "border",
+    format: str = "pretty",
     start_date: str | None = None,
     end_date: str | None = None,
     sort: bool = True,
@@ -176,7 +176,7 @@ def pypi_stats_api(
 
     if (
         color != "no"
-        and format in ("border", "markdown", "rst", "tsv")
+        and format in ("markdown", "pretty", "rst", "tsv")
         and _can_do_colour()
     ):
         data = _colourify(data)
@@ -370,7 +370,7 @@ def _colourify(data) -> list:
     return data
 
 
-def _tabulate(data: dict | list, format: str = "markdown"):
+def _tabulate(data: dict | list, format_: str = "markdown"):
     """Return data in specified format"""
 
     if isinstance(data, dict):
@@ -382,17 +382,17 @@ def _tabulate(data: dict | list, format: str = "markdown"):
     headers.append("downloads")
     headers.remove("downloads")
 
-    if format in ("border", "markdown"):
-        return _prettytable(headers, data, format)
+    if format_ in ("markdown", "pretty"):
+        return _prettytable(headers, data, format_)
     else:
-        return _pytablewriter(headers, data, format)
+        return _pytablewriter(headers, data, format_)
 
 
-def _prettytable(headers: list[str], data: dict | list, format: str) -> str:
+def _prettytable(headers: list[str], data: dict | list, format_: str) -> str:
     from prettytable import MARKDOWN, SINGLE_BORDER, PrettyTable
 
     x = PrettyTable()
-    if format == "markdown":
+    if format_ == "markdown":
         x.set_style(MARKDOWN)
     else:
         x.set_style(SINGLE_BORDER)
@@ -416,7 +416,7 @@ def _prettytable(headers: list[str], data: dict | list, format: str) -> str:
     return x.get_string() + "\n"
 
 
-def _pytablewriter(headers, data, format: str):
+def _pytablewriter(headers, data, format_: str):
     from pytablewriter import (
         HtmlTableWriter,
         NumpyTableWriter,
@@ -435,8 +435,8 @@ def _pytablewriter(headers, data, format: str):
         "tsv": TsvTableWriter,
     }
 
-    writer = format_writers[format]()
-    if format != "html":
+    writer = format_writers[format_]()
+    if format_ != "html":
         writer.margin = 1
 
     if isinstance(data, dict):
@@ -460,7 +460,7 @@ def _pytablewriter(headers, data, format: str):
             type_hint = None
             if header == "percent":
                 align = Align.RIGHT
-            elif header == "downloads" and (format not in ["numpy", "pandas"]):
+            elif header == "downloads" and (format_ not in ["numpy", "pandas"]):
                 thousand_separator = ","
             elif header == "category":
                 type_hint = String
@@ -471,9 +471,9 @@ def _pytablewriter(headers, data, format: str):
         writer.column_styles = column_styles
         writer.type_hints = type_hints
 
-    if format == "numpy":
+    if format_ == "numpy":
         return writer.tabledata.as_dataframe().values
-    elif format == "pandas":
+    elif format_ == "pandas":
         return writer.tabledata.as_dataframe()
     return writer.dumps()
 

--- a/src/pypistats/cli.py
+++ b/src/pypistats/cli.py
@@ -118,7 +118,7 @@ def _define_format(args: argparse.Namespace) -> str:
     return args.format
 
 
-FORMATS = ("border", "html", "json", "md", "markdown", "rich", "rst", "tsv")
+FORMATS = ("html", "json", "pretty", "md", "markdown", "rich", "rst", "tsv")
 
 arg_start_date = argument(
     "-sd",
@@ -154,7 +154,7 @@ arg_json = argument("-j", "--json", action="store_true", help='Shortcut for "-f 
 arg_daily = argument("-d", "--daily", action="store_true", help="Show daily downloads")
 arg_monthly = argument("--monthly", action="store_true", help="Show monthly downloads")
 arg_format = argument(
-    "-f", "--format", default="border", choices=FORMATS, help="The format of output"
+    "-f", "--format", default="pretty", choices=FORMATS, help="The format of output"
 )
 arg_color = argument(
     "-c",

--- a/tests/data/expected_tabulated.py
+++ b/tests/data/expected_tabulated.py
@@ -62,7 +62,7 @@ EXPECTED_TABULATED_HTML = """
 </table>
         """
 
-EXPECTED_TABULATED_BORDER = """
+EXPECTED_TABULATED_PRETTY = """
 ┌──────────┬────────────┬───────────┐
 │ category │    date    │ downloads │
 ├──────────┼────────────┼───────────┤

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -13,9 +13,9 @@ import respx
 import pypistats
 
 from .data.expected_tabulated import (
-    EXPECTED_TABULATED_BORDER,
     EXPECTED_TABULATED_HTML,
     EXPECTED_TABULATED_MD,
+    EXPECTED_TABULATED_PRETTY,
     EXPECTED_TABULATED_RST,
     EXPECTED_TABULATED_TSV,
 )
@@ -257,8 +257,8 @@ class TestPypiStats:
         "test_input, expected",
         [
             pytest.param("html", EXPECTED_TABULATED_HTML, id="html"),
-            pytest.param("border", EXPECTED_TABULATED_BORDER, id="border"),
             pytest.param("markdown", EXPECTED_TABULATED_MD, id="markdown"),
+            pytest.param("pretty", EXPECTED_TABULATED_PRETTY, id="pretty"),
             pytest.param("rst", EXPECTED_TABULATED_RST, id="rst"),
             pytest.param("tsv", EXPECTED_TABULATED_TSV, id="tsv"),
         ],
@@ -268,7 +268,7 @@ class TestPypiStats:
         data = copy.deepcopy(SAMPLE_DATA)
 
         # Act
-        output = pypistats._tabulate(data, format=test_input)
+        output = pypistats._tabulate(data, format_=test_input)
 
         # Assert
         assert output.strip() == expected.strip()
@@ -715,7 +715,7 @@ Date range: 2020-05-01 - 2020-05-01
 """
 
         # Act
-        output = pypistats._tabulate(data, format="markdown")
+        output = pypistats._tabulate(data, format_="markdown")
 
         # Assert
         assert output.strip() == expected_output.strip()


### PR DESCRIPTION
Follow on to https://github.com/hugovk/pypistats/pull/347.

Let's call it `--format pretty` instead of `--format border`.