### PR TITLE
Make runnable via 'python -m pypistats'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,3 +9,7 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if __name__ == .__main__.:
     def main
+
+[run]
+omit =
+    **/pypistats/__main__.py

--- a/src/pypistats/__main__.py
+++ b/src/pypistats/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from pypistats import cli
+
+if __name__ == "__main__":
+    cli.main()


### PR DESCRIPTION
# Before

```console
$ pypy3 -m pypistats recent pillow
/Users/hugo/.pyenv/versions/pypy3.9-7.3.9/bin/pypy3: No module named pypistats.__main__; 'pypistats' is a package and cannot be directly executed
```

# After

```console
$ pypy3 -m pypistats recent pillow
┌───────────┬────────────┬───────────┐
│  last_day │ last_month │ last_week │
├───────────┼────────────┼───────────┤
│ 1,308,333 │ 46,570,871 │ 8,761,810 │
└───────────┴────────────┴───────────┘
```