### PR TITLE
Make headers bold and let termcolor 2.1 determine if colour can be used

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Tox tests (pins)
         if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
-        shell: bash
         run: |
           tox -e pins
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: [--py37-plus]
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         args: [--target-version=py37]
@@ -23,7 +23,7 @@ repos:
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
 
@@ -38,17 +38,17 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.4.1
+    rev: 0.6.0
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.10.1
+    rev: v0.12.1
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 0.5.2
+    rev: 0.6.1
     hooks:
       - id: tox-ini-fmt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,19 +19,6 @@ keywords = [
 license = {text = "MIT"}
 authors = [{name = "Hugo van Kemenade"}]
 requires-python = ">=3.7"
-dependencies = [
-  "httpx>=0.19",
-  'importlib-metadata; python_version < "3.8"',
-  "platformdirs",
-  "prettytable>=2.4",
-  "pytablewriter[html]>=0.63",
-  "python-dateutil",
-  "python-slugify",
-  "termcolor",
-]
-dynamic = [
-  "version",
-]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -47,6 +34,19 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+]
+dynamic = [
+  "version",
+]
+dependencies = [
+  "httpx>=0.19",
+  'importlib-metadata; python_version < "3.8"',
+  "platformdirs",
+  "prettytable>=2.4",
+  "pytablewriter[html]>=0.63",
+  "python-dateutil",
+  "python-slugify",
+  "termcolor>=2.1",
 ]
 [project.optional-dependencies]
 numpy = [
@@ -70,9 +70,6 @@ Source = "https://github.com/hugovk/pypistats"
 [project.scripts]
 pypistats = "pypistats.cli:main"
 
-
-[tool.black]
-target_version = ["py37"]
 
 [tool.hatch]
 version.source = "vcs"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,10 @@ httpx==0.23.3
 numpy==1.24.1
 pandas==1.5.3
 platformdirs==2.6.2
+prettytable==3.6.0
 pytablewriter[html]==0.64.2
 pytest==7.2.1
 pytest-cov==4.0.0
 python-slugify==8.0.0
 respx==0.20.1
+termcolor==2.2.0

--- a/src/pypistats/cli.py
+++ b/src/pypistats/cli.py
@@ -321,7 +321,6 @@ def main() -> None:
     if args.subcommand is None:
         cli.print_help()
     else:
-
         # Convert yyyy-mm to yyyy-mm-dd
         if hasattr(args, "start_date") and args.start_date:
             try:

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -3,9 +3,7 @@ Unit tests for pypistats
 """
 import copy
 import json
-import os
 from pathlib import Path
-from unittest import mock
 
 import pytest
 import respx
@@ -205,16 +203,6 @@ class TestPypiStats:
 
         # Assert
         assert param == expected
-
-    @mock.patch.dict(os.environ, {"NO_COLOR": "TRUE"})
-    def test__can_do_colour_no_color(self) -> None:
-        # Act / Assert
-        assert pypistats._can_do_colour() is False
-
-    @mock.patch.dict(os.environ, {"FORCE_COLOR": "TRUE"})
-    def test__can_do_colour_force_colour(self) -> None:
-        # Act / Assert
-        assert pypistats._can_do_colour() is True
 
     def test__colourify(self, monkeypatch) -> None:
         # Arrange


### PR DESCRIPTION
Like https://github.com/hugovk/norwegianblue/pull/130.

https://github.com/termcolor/termcolor/releases/tag/2.1.0 added support to detect if colour can be used by the terminal, so we can depend on `termcolor>2.1` and remove that code from here.

Also make headers bold (when ANSI colour codes available).
