### PR TITLE
Fix formatting for bold headers

### DIFF
--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -380,22 +380,27 @@ def _prettytable(
 
     if isinstance(data, dict):
         data = [data]
+
+    # Apply bold to header?
+    def h(header: str) -> str:
+        if color != "no" and format_ == "pretty":
+            return colored(header, attrs=["bold"])
+        return header
+
     for header in headers:
         col_data = [row[header] if header in row else "" for row in data]
-        if color != "no" and format_ == "pretty":
-            x.add_column(colored(header, attrs=["bold"]), col_data)
-        else:
-            x.add_column(header, col_data)
-        x.align["last_day"] = "r"
-        x.align["last_month"] = "r"
-        x.align["last_week"] = "r"
-        x.align["category"] = "l"
-        x.align["percent"] = "r"
-        x.align["downloads"] = "r"
-        x.custom_format["last_day"] = lambda f, v: f"{v:,}"
-        x.custom_format["last_month"] = lambda f, v: f"{v:,}"
-        x.custom_format["last_week"] = lambda f, v: f"{v:,}"
-        x.custom_format["downloads"] = lambda f, v: f"{v:,}"
+        x.add_column(h(header), col_data)
+
+    x.align[h("last_day")] = "r"
+    x.align[h("last_month")] = "r"
+    x.align[h("last_week")] = "r"
+    x.align[h("category")] = "l"
+    x.align[h("percent")] = "r"
+    x.align[h("downloads")] = "r"
+    x.custom_format[h("last_day")] = lambda f, v: f"{v:,}"
+    x.custom_format[h("last_month")] = lambda f, v: f"{v:,}"
+    x.custom_format[h("last_week")] = lambda f, v: f"{v:,}"
+    x.custom_format[h("downloads")] = lambda f, v: f"{v:,}"
 
     return x.get_string() + "\n"
 


### PR DESCRIPTION
https://github.com/hugovk/pypistats/pull/377 introduced an (unreleased) bug.

# Before bug

For example: `pypistats python_minor pypistats --last-month`

<img width="246" alt="image" src="https://user-images.githubusercontent.com/1324225/218866729-24433e39-0247-4783-a8dc-77fe43199e70.png">

# With bug

<img width="242" alt="image" src="https://user-images.githubusercontent.com/1324225/218866844-7a6dfe90-da8d-4a62-b946-c95aa1c77f79.png">

Problem is that this:

```python
        if color != "no" and format_ == "pretty":
            x.add_column(colored(header, attrs=["bold"]), col_data)
        else:
            x.add_column(header, col_data)
```

adds a header like `"downloads"`, but with the ANSI colour codes on either side.

Then when we do things like `x.align["downloads"] = "r"`, that's for a column _without_ the ANSI codes.

To fix, make sure they match.

Also no need to set aligns and custom formatting in the loop.