### PR TITLE
Remove broken codecov

### DIFF
--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -40,9 +40,3 @@ jobs:
           pypistats --help
           pypistats recent --help
         displayName: "Test runs"
-
-      - script: |
-          python -m pip install --upgrade codecov
-          codecov --name "Azure: ${{ parameters.name }} Python $(python.version)" --build $(Build.BuildNumber) --token $(CODECOV_TOKEN)
-        condition: succeeded()
-        displayName: "Upload to Codecov"


### PR DESCRIPTION
Codecov had deprecated their Python codecov package:

* https://about.codecov.io/blog/introducing-codecovs-new-uploader/

But rather than only deprecating it, they've completely deleted the package from PyPI:

* https://pypi.org/project/codecov/
* https://github.com/codecov/python-standard/issues/31
* https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259?u=hugovk

This will cause CI failures.

Let's remove Codecov from Azure Pipelines. We're using the action for GitHub Actions.