### PR TITLE
Add validators for 'python_major' and 'python_minor' arguments

### DIFF
--- a/src/pypistats/cli.py
+++ b/src/pypistats/cli.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import re
+from typing import Any
 
 from dateutil.relativedelta import relativedelta
 
@@ -118,6 +120,25 @@ def _define_format(args: argparse.Namespace) -> str:
     return args.format
 
 
+def _python_major_version(value: Any) -> int | None:
+    pattern = r"^\d+$"  # x format
+    if not re.match(pattern, value):
+        msg = "Invalid major version format. Expected a positive integer value"
+        raise argparse.ArgumentTypeError(msg)
+    return value
+
+
+def _python_minor_version(value: Any) -> int | None:
+    pattern = r"^\d+\.\d+$"  # x.x format
+    if not re.match(pattern, value):
+        msg = (
+            "Invalid minor version format."
+            "Expected a positive float value in x.x pattern"
+        )
+        raise argparse.ArgumentTypeError(msg)
+    return value
+
+
 FORMATS = ("html", "json", "pretty", "md", "markdown", "rst", "tsv")
 
 arg_start_date = argument(
@@ -228,7 +249,7 @@ def overall(args: argparse.Namespace) -> None:  # pragma: no cover
 @subcommand(
     [
         argument("package"),
-        argument("-V", "--version", help="eg. 2 or 3"),
+        argument("-V", "--version", help="eg. 2 or 3", type=_python_major_version),
         *common_arguments,
     ]
 )
@@ -250,7 +271,7 @@ def python_major(args: argparse.Namespace) -> None:  # pragma: no cover
 @subcommand(
     [
         argument("package"),
-        argument("-V", "--version", help="eg. 2.7 or 3.6"),
+        argument("-V", "--version", help="eg. 2.7 or 3.6", type=_python_minor_version),
         *common_arguments,
     ]
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,3 +172,29 @@ def test__define_format_format_flag(test_input: str) -> None:
 
     # Assert
     assert test_input == _format
+
+
+@pytest.mark.parametrize("test_input", ["2", "3", "4"])
+def test__python_major_version_valid(test_input: str) -> None:
+    # Act / Assert
+    assert cli._python_major_version(test_input) == test_input
+
+
+@pytest.mark.parametrize("test_input", ["2.7", "3.9", "3.11", "-5", "pillow"])
+def test__python_major_version_invalid(test_input) -> None:
+    # Act / Assert
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli._python_major_version(test_input)
+
+
+@pytest.mark.parametrize("test_input", ["2.7", "3.9", "3.11"])
+def test__python_minor_version_valid(test_input: str) -> None:
+    # Act / Assert
+    assert cli._python_minor_version(test_input) == test_input
+
+
+@pytest.mark.parametrize("test_input", ["2", "3", "4", "-5", "pillow"])
+def test__python_minor_version_invalid(test_input: str) -> None:
+    # Act / Assert
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli._python_minor_version(test_input)


### PR DESCRIPTION
- [x] `argparse` validators implementation
- [x] add cli tests