### PR TITLE
Add type hints to fix some mypy warnings

### DIFF
--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -213,7 +213,7 @@ def _sort(data: dict | list) -> dict | list:
 def _monthly_total(data: list) -> list:
     """Sum all downloads per category, by month"""
 
-    totalled = {}
+    totalled: dict = {}
     for row in data:
         category = row["category"]
         downloads = row["downloads"]
@@ -242,7 +242,7 @@ def _total(data: dict | list) -> dict | list:
     if isinstance(data, dict):
         return data
 
-    totalled = {}
+    totalled: dict = {}
     for row in data:
         try:
             totalled[row["category"]] += row["downloads"]
@@ -446,7 +446,7 @@ def _pytablewriter(headers, data, format_: str):
             if header == "percent":
                 align = Align.RIGHT
             elif header == "downloads" and (format_ not in ["numpy", "pandas"]):
-                thousand_separator = ","
+                thousand_separator = ThousandSeparator.COMMA
             elif header == "category":
                 type_hint = String
             style = Style(align=align, thousand_separator=thousand_separator)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -144,8 +144,9 @@ def test__valid_yyyy_mm_optional_dd_invalid(test_input: str) -> None:
         cli._valid_yyyy_mm_optional_dd(test_input)
 
 
-class __Args:
-    def __init__(self) -> None:
+class __Args(argparse.Namespace):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.json = False  # type: bool
         self.format = "markdown"  # type: str
 

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -69,8 +69,8 @@ class TestPypiStats:
         # Stub caching. Caches are tested in another class.
         self.original__cache_filename = pypistats._cache_filename
         self.original__save_cache = pypistats._save_cache
-        pypistats._cache_filename = stub__cache_filename
-        pypistats._save_cache = stub__save_cache
+        pypistats._cache_filename = stub__cache_filename  # type: ignore[assignment]
+        pypistats._save_cache = stub__save_cache  # type: ignore[assignment]
 
     def teardown_method(self) -> None:
         # Unstub caching
@@ -213,12 +213,12 @@ class TestPypiStats:
             {"category": "3.10", "downloads": 89, "percent": "\x1b[32m89.00%\x1b[0m"},
             {"category": "Total", "downloads": 100},
         ]
-        data = pypistats._percent(data)
-        data = pypistats._grand_total(data)
+        percent_data = pypistats._percent(data)
+        total_data = pypistats._grand_total(percent_data)
         monkeypatch.setenv("FORCE_COLOR", "1")
 
         # Act
-        output = pypistats._colourify(data)
+        output = pypistats._colourify(total_data)
 
         # Assert
         assert output == expected_output


### PR DESCRIPTION
Doesn't fix all the warnings, but does some.

Here's pre-commit config for mypy:

```yaml
  - repo: https://github.com/pre-commit/mirrors-mypy
    rev: v1.8.0
    hooks:
      - id: mypy
        args: [--pretty, --show-error-codes]
        additional_dependencies:
          [
            freezegun,
            platformdirs,
            prettytable,
            pytablewriter,
            pytest,
            respx,
            termcolor,
            types-python-dateutil,
            types-python-slugify,
          ]
```
