### PR TITLE
Attest build provenance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,7 @@ jobs:
     needs: build-package
 
     permissions:
+      attestations: write
       id-token: write
 
     steps:
@@ -46,6 +47,11 @@ jobs:
         with:
           name: Packages
           path: dist
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "dist/*"
 
       - name: Upload package to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -62,6 +68,7 @@ jobs:
     needs: build-package
 
     permissions:
+      attestations: write
       id-token: write
 
     steps:
@@ -70,6 +77,11 @@ jobs:
         with:
           name: Packages
           path: dist
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "dist/*"
 
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Attest using GitHub's Artifact Attestations:

* https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/