### PR TITLE
Generate `__version__` at build to avoid slow `importlib.metadata` import

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   # Always build & lint package.
   build-package:

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# hatch-vcs
+src/pypistats/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,19 +84,26 @@ lint.select = [
   "EM",     # flake8-errmsg
   "F",      # pyflakes errors
   "I",      # isort
+  "ICN",    # flake8-import-conventions
   "ISC",    # flake8-implicit-str-concat
   "LOG",    # flake8-logging
   "PGH",    # pygrep-hooks
+  "PYI",    # flake8-pyi
+  "RUF022", # unsorted-dunder-all
   "RUF100", # unused noqa (yesqa)
   "UP",     # pyupgrade
   "W",      # pycodestyle warnings
   "YTT",    # flake8-2020
 ]
-lint.extend-ignore = [
+lint.ignore = [
   "E203", # Whitespace before ':'
   "E221", # Multiple spaces before operator
   "E226", # Missing whitespace around arithmetic operator
   "E241", # Multiple spaces after ','
+]
+lint.flake8-import-conventions.aliases.datetime = "dt"
+lint.flake8-import-conventions.banned-from = [
+  "datetime",
 ]
 lint.isort.known-first-party = [
   "pypistats",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ scripts.pypistats = "pypistats.cli:main"
 [tool.hatch]
 version.source = "vcs"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/pypistats/_version.py"
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import atexit
 import datetime as dt
-import importlib.metadata
 import json
 import sys
 import warnings
@@ -17,7 +16,9 @@ from platformdirs import user_cache_dir
 from slugify import slugify
 from termcolor import colored
 
-__version__ = importlib.metadata.version(__name__)
+from . import _version
+
+__version__ = _version.__version__
 
 BASE_URL = "https://pypistats.org/api/"
 CACHE_DIR = Path(user_cache_dir("pypistats"))


### PR DESCRIPTION
With Python 3.12.4:

```sh
python -X importtime -c "import pypistats" 2> import.log && tuna import.log
```

Cuts out the 23ms `importlib.metadata` import.

# `main`

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/4c8a1e9b-889b-4a0b-95cc-8c8366d49caf">

```console
❯ hyperfine --warmup 8 "pypistats --version"
Benchmark 1: pypistats --version
  Time (mean ± σ):      57.2 ms ±   3.3 ms    [User: 44.6 ms, System: 10.9 ms]
  Range (min … max):    51.7 ms …  72.8 ms    48 runs
```

# PR

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/1a4166e2-59bc-4a00-a341-8347be91f9ac">


```console
❯ hyperfine --warmup 8 "pypistats --version"
Benchmark 1: pypistats --version
  Time (mean ± σ):      37.4 ms ±   2.7 ms    [User: 29.0 ms, System: 7.3 ms]
  Range (min … max):    34.6 ms …  55.4 ms    74 runs
```

---

And update some config.
