### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -9,8 +9,6 @@ jobs:
 
     strategy:
       matrix:
-        Python38:
-          python.version: "3.8"
         Python39:
           python.version: "3.9"
         Python310:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
@@ -46,7 +46,7 @@ jobs:
         uses: codecov/codecov-action@v3.1.5
         with:
           flags: ${{ matrix.os }}
-          name: "${{ matrix.os }} Python ${{ matrix.python-version }}"
+          name: ${{ matrix.os }} Python ${{ matrix.python-version }}
 
   success:
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -112,4 +112,4 @@ venv.bak/
 dmypy.json
 
 # hatch-vcs
-src/pypistats/_version.py
+src/*/_version.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.0
+    rev: v0.6.5
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
 
@@ -27,7 +27,7 @@ repos:
         exclude: tests/data/expected_tabulated.py
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.6
+    rev: 0.29.2
     hooks:
       - id: check-github-workflows
       - id: check-renovate
@@ -38,22 +38,22 @@ repos:
       - id: actionlint
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 2.1.3
+    rev: 2.2.3
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.18
+    rev: v0.19
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.3.1
+    rev: 1.4.0
     hooks:
       - id: tox-ini-fmt
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,7 @@ keywords = [
   "stats",
 ]
 license = { text = "MIT" }
-authors = [
-  { name = "Hugo van Kemenade" },
-]
+authors = [ { name = "Hugo van Kemenade" } ]
 requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -36,9 +34,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dynamic = [
-  "version",
-]
+dynamic = [ "version" ]
 dependencies = [
   "httpx>=0.19",
   "platformdirs",
@@ -101,15 +97,9 @@ lint.ignore = [
   "E241", # Multiple spaces after ','
 ]
 lint.flake8-import-conventions.aliases.datetime = "dt"
-lint.flake8-import-conventions.banned-from = [
-  "datetime",
-]
-lint.isort.known-first-party = [
-  "pypistats",
-]
-lint.isort.required-imports = [
-  "from __future__ import annotations",
-]
+lint.flake8-import-conventions.banned-from = [ "datetime" ]
+lint.isort.known-first-party = [ "pypistats" ]
+lint.isort.required-imports = [ "from __future__ import annotations" ]
 
 [tool.pyproject-fmt]
 max_supported_python = "3.13"
@@ -120,6 +110,4 @@ filterwarnings = [
   # Python <= 3.11
   "ignore:sys.monitoring isn't available, using default core:coverage.exceptions.CoverageWarning",
 ]
-testpaths = [
-  "tests",
-]
+testpaths = [ "tests" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ license = { text = "MIT" }
 authors = [
   { name = "Hugo van Kemenade" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -28,7 +28,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ env_list =
     cog
     lint
     pins
-    py{py3, 313, 312, 311, 310, 39, 38}
+    py{py3, 313, 312, 311, 310, 39}
 
 [testenv]
 extras =


### PR DESCRIPTION
Python 3.8 is end-of-life next month:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/#lifespan