### PR TITLE
Generate digital attestations for PyPI (PEP 740)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Upload package to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          attestations: true
           repository-url: https://test.pypi.org/legacy/
 
   # Upload to real PyPI on GitHub Releases.
@@ -88,3 +89,5 @@ jobs:
 
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true


### PR DESCRIPTION
PEP 740 ("Index support for digital attestations") introduces signatures which links the PyPI package to the GitHub repo, and helps users verify the source and authenticity of packages.

PyPI is still implementing support, but we can already start using it, which should also help them test out.

* https://peps.python.org/pep-0740/
* https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations
* https://github.com/pypi/warehouse/issues/15871
