### PR TITLE
Revert "Update requirements.txt and temporarily pin HTTPX pending RESPX compatibility"

### DIFF
--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -30,7 +30,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install  -e ".[numpy,pandas,tests]"
           python -m pip install --upgrade pytest-azurepipelines
-          python -m pip install "httpx==0.27.2"
         displayName: "Install dependencies"
 
       - script: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,14 +33,12 @@ jobs:
           python -m pip install -U pip
           python -m pip install -U tox
 
-      # Temporarily pin HTTPX pending RESPX compatibility
-      # - name: Tox tests
-      #  run: |
-      #    tox -e py
+      - name: Tox tests
+        run: |
+          tox -e py
 
       - name: Tox tests (pins)
-        # Temporarily pin HTTPX pending RESPX compatibility
-        # if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
         run: |
           tox -e pins
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,12 @@
 # Only for testing pinned versions on the CI
 freezegun==1.5.1
-httpx==0.27.2  # Temporarily pin HTTPX pending RESPX compatibility
-numpy==2.1.3; python_version >= "3.10"
-numpy; python_version <= "3.9"
+httpx==0.27.2
+numpy==2.1.2
 pandas==2.2.3
 platformdirs==4.3.6
 prettytable==3.12.0
 pytablewriter[html]==1.2.0
-pytest==8.3.4
+pytest==8.3.3
 pytest-cov==6.0.0
 python-slugify==8.0.4
 respx==0.21.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Only for testing pinned versions on the CI
 freezegun==1.5.1
-httpx==0.27.2
+httpx==0.28.1
 numpy==2.1.2
 pandas==2.2.3
 platformdirs==4.3.6
@@ -9,5 +9,5 @@ pytablewriter[html]==1.2.0
 pytest==8.3.3
 pytest-cov==6.0.0
 python-slugify==8.0.4
-respx==0.21.1
+respx==0.22.0
 termcolor==2.5.0


### PR DESCRIPTION
Undo https://github.com/hugovk/pypistats/pull/458 now RESPX has been released with support for the new HTTPX.