### PR TITLE
Use `format=None` to return raw Python data structure

### DIFF
--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -85,7 +85,7 @@ atexit.register(_clear_cache)
 def pypi_stats_api(
     endpoint: str,
     params: str | None = None,
-    format: str = "pretty",
+    format: str | None = "pretty",
     start_date: str | None = None,
     end_date: str | None = None,
     sort: bool = True,
@@ -172,6 +172,9 @@ def pypi_stats_api(
 
     data = _percent(data)
     data = _grand_total(data)
+
+    if format is None:
+        return data
 
     if color != "no" and format in ("markdown", "pretty", "rst", "tsv"):
         data = _colourify(data)

--- a/tests/test_pypistats.py
+++ b/tests/test_pypistats.py
@@ -749,6 +749,25 @@ Date range: 2020-05-01 - 2020-05-01
         assert str(output).strip() == expected_output.strip()
 
     @respx.mock
+    def test_format_none(self) -> None:
+        # Arrange
+        package = "pip"
+        mocked_url = "https://pypistats.org/api/packages/pip/overall"
+        mocked_response = SAMPLE_RESPONSE_OVERALL
+        expected_output = {
+            "category": "with_mirrors",
+            "downloads": 3587357,
+            "percent": "100.00%",
+        }
+
+        # Act
+        respx.get(mocked_url).respond(content=mocked_response)
+        output = pypistats.overall(package, format=None)
+
+        # Assert
+        assert output[0] == expected_output
+
+    @respx.mock
     def test_package_not_exist(self) -> None:
         # Arrange
         package = "a" * 100


### PR DESCRIPTION
Fixes https://github.com/hugovk/pypistats/issues/432.

For example:

```pycon
>>> import pypistats
>>> pypistats.recent("pip", format=None)
{'last_day': 6409346, 'last_month': 271410103, 'last_week': 68642673}
```