### PR TITLE
Updated docs for recent command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ usage: pypistats recent [-h] [-p {day,week,month}]
                         [-v]
                         package
 
-Retrieve the aggregate download quantities for the last day/week/month
+Retrieve the aggregate download quantities for the last 1/7/30 days, only
+includes without mirror downloads
 
 positional arguments:
   package

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ usage: pypistats recent [-h] [-p {day,week,month}]
                         [-v]
                         package
 
-Retrieve the aggregate download quantities for the last 1/7/30 days, only
-includes without mirror downloads
+Retrieve the aggregate download quantities for the last 1/7/30 days,
+excluding downloads from mirrors
 
 positional arguments:
   package

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -484,7 +484,8 @@ def _paramify(param_name: str, param_value: float | str | None) -> str:
 
 
 def recent(package: str, period: str | None = None, **kwargs: str):
-    """Retrieve the aggregate download quantities for the last day/week/month"""
+    """Retrieve the aggregate download quantities for the last 1/7/30 days, 
+    only includes without mirror downloads."""
     endpoint = f"packages/{package}/recent"
     params = _paramify("period", period)
     return pypi_stats_api(endpoint, params, **kwargs)

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -485,7 +485,7 @@ def _paramify(param_name: str, param_value: float | str | None) -> str:
 
 def recent(package: str, period: str | None = None, **kwargs: str):
     """Retrieve the aggregate download quantities for the last 1/7/30 days,
-    only includes without mirror downloads."""
+    excluding downloads from mirrors"""
     endpoint = f"packages/{package}/recent"
     params = _paramify("period", period)
     return pypi_stats_api(endpoint, params, **kwargs)

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -484,7 +484,7 @@ def _paramify(param_name: str, param_value: float | str | None) -> str:
 
 
 def recent(package: str, period: str | None = None, **kwargs: str):
-    """Retrieve the aggregate download quantities for the last 1/7/30 days, 
+    """Retrieve the aggregate download quantities for the last 1/7/30 days,
     only includes without mirror downloads."""
     endpoint = f"packages/{package}/recent"
     params = _paramify("period", period)


### PR DESCRIPTION
Fixes #470.

Updated docs for `recent` command as discussed in #470. 