### PR TITLE
Enable colour help for Python 3.14

### DIFF
--- a/src/pypistats/cli.py
+++ b/src/pypistats/cli.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from typing import Any
 
 cli = argparse.ArgumentParser()
+cli.color = True
 subparsers = cli.add_subparsers(dest="subcommand")
 
 


### PR DESCRIPTION
Will be available for 3.14 beta:

https://docs.python.org/3.14/library/argparse.html#color

<table>
<tr>
<th>Before
<th>After
<tr>
<td>
<img width="801" alt="image" src="https://github.com/user-attachments/assets/4a9d0102-fed6-46a0-ab0f-de168c9a157f" />
<td>
<img width="801" alt="image" src="https://github.com/user-attachments/assets/926494b2-0406-45eb-a1ea-6f176b4779a3" />
</table>