### PR TITLE
Allow directory as package to get name from pyproject.toml/setup.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Retrieve the aggregate download quantities for the last 1/7/30 days,
 excluding downloads from mirrors
 
 positional arguments:
-  package
+  package               package name, or dir to check pyproject.toml/setup.cfg (default: .)
 
 options:
   -h, --help            show this help message and exit
@@ -97,7 +97,7 @@ $ pypistats recent pillow
 ┌───────────┬─────────────┬────────────┐
 │  last_day │  last_month │  last_week │
 ├───────────┼─────────────┼────────────┤
-│ 5,142,717 │ 125,777,276 │ 30,415,118 │
+│ 7,099,431 │ 184,980,272 │ 43,134,813 │
 └───────────┴─────────────┴────────────┘
 ```
 
@@ -119,7 +119,7 @@ usage: pypistats python_minor [-h] [-V VERSION]
 Retrieve the aggregate daily download time series by Python minor version number
 
 positional arguments:
-  package
+  package               package name, or dir to check pyproject.toml/setup.cfg (default: .)
 
 options:
   -h, --help            show this help message and exit
@@ -154,27 +154,27 @@ $ pypistats python_minor pillow --last-month
 ┌──────────┬─────────┬─────────────┐
 │ category │ percent │   downloads │
 ├──────────┼─────────┼─────────────┤
-│ 3.10     │  19.31% │  24,065,642 │
-│ 3.11     │  17.45% │  21,749,566 │
-│ 3.12     │  15.68% │  19,541,358 │
-│ 3.9      │  13.93% │  17,370,148 │
-│ 3.7      │  12.86% │  16,034,418 │
-│ 3.8      │   9.69% │  12,077,524 │
-│ null     │   5.89% │   7,341,287 │
-│ 3.13     │   2.99% │   3,728,426 │
-│ 3.6      │   1.81% │   2,255,947 │
-│ 2.7      │   0.38% │     468,671 │
-│ 3.5      │   0.01% │      15,575 │
-│ 3.14     │   0.00% │       5,804 │
-│ 3.4      │   0.00% │         907 │
-│ 3.1      │   0.00% │          37 │
-│ 3.3      │   0.00% │          16 │
-│ 3.2      │   0.00% │           6 │
-│ 3.99     │   0.00% │           1 │
-│ Total    │         │ 124,655,333 │
+│ 3.11     │  21.79% │  39,303,874 │
+│ 3.12     │  18.85% │  34,005,926 │
+│ 3.10     │  16.91% │  30,503,181 │
+│ 3.9      │  12.22% │  22,039,674 │
+│ 3.7      │   9.35% │  16,857,870 │
+│ 3.13     │   8.24% │  14,866,029 │
+│ 3.8      │   5.47% │   9,860,598 │
+│ null     │   4.99% │   9,003,488 │
+│ 3.6      │   1.86% │   3,360,527 │
+│ 2.7      │   0.30% │     550,163 │
+│ 3.14     │   0.01% │      19,461 │
+│ 3.5      │   0.01% │      17,119 │
+│ 3.4      │   0.00% │         579 │
+│ 3.15     │   0.00% │         398 │
+│ 2.6      │   0.00% │          20 │
+│ 3.3      │   0.00% │          19 │
+│ 3.1      │   0.00% │           1 │
+│ Total    │         │ 180,388,927 │
 └──────────┴─────────┴─────────────┘
 
-Date range: 2025-01-01 - 2025-01-31
+Date range: 2025-07-01 - 2025-07-31
 ```
 
 <!-- [[[end]]] -->
@@ -185,26 +185,26 @@ You can format in Markdown, ready for pasting in GitHub issues and PRs:
 
 | category | percent |   downloads |
 | :------- | ------: | ----------: |
-| 3.10     |  19.31% |  24,065,642 |
-| 3.11     |  17.45% |  21,749,566 |
-| 3.12     |  15.68% |  19,541,358 |
-| 3.9      |  13.93% |  17,370,148 |
-| 3.7      |  12.86% |  16,034,418 |
-| 3.8      |   9.69% |  12,077,524 |
-| null     |   5.89% |   7,341,287 |
-| 3.13     |   2.99% |   3,728,426 |
-| 3.6      |   1.81% |   2,255,947 |
-| 2.7      |   0.38% |     468,671 |
-| 3.5      |   0.01% |      15,575 |
-| 3.14     |   0.00% |       5,804 |
-| 3.4      |   0.00% |         907 |
-| 3.1      |   0.00% |          37 |
-| 3.3      |   0.00% |          16 |
-| 3.2      |   0.00% |           6 |
-| 3.99     |   0.00% |           1 |
-| Total    |         | 124,655,333 |
+| 3.11     |  21.79% |  39,303,874 |
+| 3.12     |  18.85% |  34,005,926 |
+| 3.10     |  16.91% |  30,503,181 |
+| 3.9      |  12.22% |  22,039,674 |
+| 3.7      |   9.35% |  16,857,870 |
+| 3.13     |   8.24% |  14,866,029 |
+| 3.8      |   5.47% |   9,860,598 |
+| null     |   4.99% |   9,003,488 |
+| 3.6      |   1.86% |   3,360,527 |
+| 2.7      |   0.30% |     550,163 |
+| 3.14     |   0.01% |      19,461 |
+| 3.5      |   0.01% |      17,119 |
+| 3.4      |   0.00% |         579 |
+| 3.15     |   0.00% |         398 |
+| 2.6      |   0.00% |          20 |
+| 3.3      |   0.00% |          19 |
+| 3.1      |   0.00% |           1 |
+| Total    |         | 180,388,927 |
 
-Date range: 2025-01-01 - 2025-01-31
+Date range: 2025-07-01 - 2025-07-31
 
 <!-- [[[end]]] -->
 
@@ -224,6 +224,35 @@ pypistats python_major pip --start-date december --end-date january
 pypistats python_major pip --start-date dec      --end-date jan
 pypistats python_major pip --start-date 2018-12  --end-date 2019-01
 ```
+
+Alternatively, use a local path as the package to look up the name from `pyproject.toml`
+or `setup.cfg`:
+
+<!-- [[[cog run("pypistats recent .") ]]] -->
+
+```console
+$ pypistats recent .
+┌──────────┬────────────┬───────────┐
+│ last_day │ last_month │ last_week │
+├──────────┼────────────┼───────────┤
+│    1,557 │     75,440 │     8,864 │
+└──────────┴────────────┴───────────┘
+```
+
+<!-- [[[end]]] -->
+
+<!-- [[[cog run("pypistats recent ../Pillow") ]]] -->
+
+```console
+$ pypistats recent ../Pillow
+┌───────────┬─────────────┬────────────┐
+│  last_day │  last_month │  last_week │
+├───────────┼─────────────┼────────────┤
+│ 7,099,431 │ 184,980,272 │ 43,134,813 │
+└───────────┴─────────────┴────────────┘
+```
+
+<!-- [[[end]]] -->
 
 ## Example programmatic use
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "python-dateutil",
   "python-slugify",
   "termcolor>=2.1",
+  "tomli; python_version<'3.11'",
 ]
 optional-dependencies.numpy = [
   "numpy",
@@ -53,6 +54,7 @@ optional-dependencies.pandas = [
 ]
 optional-dependencies.tests = [
   "freezegun",
+  "pyfakefs",
   "pytest",
   "pytest-cov",
   "respx>=0.11",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy==2.3.2
 pandas==2.3.1
 platformdirs==4.3.8
 prettytable==3.16.0
+pyfakefs==5.9.2
 pytablewriter[html]==1.2.1
 pytest==8.4.1
 pytest-cov==6.2.1


### PR DESCRIPTION
For example, in a clone of https://github.com/python-pillow/Pillow, which has `pyproject.toml`:

* https://github.com/python-pillow/Pillow/blob/092d4422d590835c5a75831a4ff29caf0df08ae2/pyproject.toml#L12

```console
❯ pypistats python_minor .
┌──────────┬─────────┬───────────────┐
│ category │ percent │     downloads │
├──────────┼─────────┼───────────────┤
│ 3.11     │  19.96% │   272,527,981 │
│ 3.10     │  17.59% │   240,077,041 │
│ 3.12     │  16.94% │   231,211,505 │
│ 3.9      │  13.57% │   185,265,217 │
│ 3.7      │  11.28% │   153,992,421 │
│ 3.8      │   7.65% │   104,473,811 │
│ 3.13     │   5.40% │    73,674,381 │
│ null     │   5.22% │    71,299,590 │
│ 3.6      │   2.06% │    28,146,475 │
│ 2.7      │   0.31% │     4,170,001 │
│ 3.5      │   0.01% │       168,356 │
│ 3.14     │   0.01% │        96,912 │
│ 3.4      │   0.00% │         7,588 │
│ 3.15     │   0.00% │         1,245 │
│ 3.3      │   0.00% │           306 │
│ 3.1      │   0.00% │            47 │
│ 2.6      │   0.00% │            21 │
│ 3.2      │   0.00% │            17 │
│ 3.99     │   0.00% │             1 │
│ Total    │         │ 1,365,112,916 │
└──────────┴─────────┴───────────────┘

Date range: 2024-11-01 - 2025-08-15
```

And from a clone of https://github.com/ultrajson/ultrajson which has a `pyproject.toml`, but that doesn't contain the name. However, `setup.cfg` does:

* https://github.com/ultrajson/ultrajson/blob/244146029f5011c32cb8e626bfe75bcde703bd5a/pyproject.toml
* https://github.com/ultrajson/ultrajson/blob/244146029f5011c32cb8e626bfe75bcde703bd5a/setup.cfg#L2

```console
❯ pypistats python_minor .
┌──────────┬─────────┬─────────────┐
│ category │ percent │   downloads │
├──────────┼─────────┼─────────────┤
│ 3.11     │  23.43% │  25,735,215 │
│ 3.12     │  17.99% │  19,760,998 │
│ 3.10     │  15.64% │  17,186,228 │
│ 3.9      │  14.07% │  15,462,618 │
│ null     │  12.26% │  13,469,002 │
│ 3.8      │   7.56% │   8,300,478 │
│ 3.7      │   4.76% │   5,233,259 │
│ 3.13     │   3.55% │   3,895,253 │
│ 3.6      │   0.50% │     553,264 │
│ 2.7      │   0.23% │     257,519 │
│ 3.14     │   0.00% │       3,124 │
│ 3.5      │   0.00% │       1,908 │
│ 3.15     │   0.00% │         541 │
│ 3.4      │   0.00% │          65 │
│ 3.3      │   0.00% │           6 │
│ Total    │         │ 109,859,478 │
└──────────┴─────────┴─────────────┘

Date range: 2025-02-17 - 2025-08-16
```

Or another directory:

```console
❯ pypistats python_minor ../Pillow
┌──────────┬─────────┬─────────────┐
│ category │ percent │   downloads │
├──────────┼─────────┼─────────────┤
│ 3.11     │  21.23% │ 201,974,090 │
│ 3.12     │  18.24% │ 173,489,516 │
│ 3.10     │  17.20% │ 163,596,832 │
│ 3.9      │  13.22% │ 125,771,563 │
│ 3.7      │   9.90% │  94,130,272 │
│ 3.13     │   6.75% │  64,238,024 │
│ 3.8      │   6.32% │  60,082,771 │
│ null     │   5.08% │  48,348,051 │
│ 3.6      │   1.76% │  16,772,111 │
│ 2.7      │   0.28% │   2,623,647 │
│ 3.5      │   0.01% │     107,811 │
│ 3.14     │   0.01% │      83,950 │
│ 3.4      │   0.00% │       4,358 │
│ 3.15     │   0.00% │       1,351 │
│ 3.3      │   0.00% │         256 │
│ 2.6      │   0.00% │          21 │
│ 3.2      │   0.00% │           7 │
│ 3.1      │   0.00% │           5 │
│ Total    │         │ 951,224,636 │
└──────────┴─────────┴─────────────┘

Date range: 2025-02-22 - 2025-08-21
```