### PR TITLE
Include human URL in verbose output

### DIFF
--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -114,8 +114,12 @@ def pypi_stats_api(
         params = ""
     url = BASE_URL + endpoint.lower() + params
     cache_file = _cache_filename(url)
-    _print_verbose(verbose, "API URL:", url)
-    _print_verbose(verbose, "Cache file:", cache_file)
+    if verbose:
+        package = endpoint.split("/")[1]
+        human_url = f"https://pypistats.org/packages/{package}"
+        _print_verbose(verbose, f"Human URL:\t{human_url}")
+        _print_verbose(verbose, f"API URL:\t{url}")
+        _print_verbose(verbose, f"Cache file:\t{cache_file}")
 
     res = {}
     if cache_file.is_file():


### PR DESCRIPTION
For example, include link to https://pypistats.org/packages/pillow

```console
❯ pypistats python_minor --verbose ../Pillow
Human URL:	https://pypistats.org/packages/pillow
API URL:	https://pypistats.org/api/packages/pillow/python_minor
Cache file:	/Users/hugo/Library/Caches/pypistats/2025-08-25-https-pypistats-org-api-packages-pillow-python-minor.json
HTTP status code: 200
┌──────────┬─────────┬─────────────┐
│ category │ percent │   downloads │
├──────────┼─────────┼─────────────┤
│ 3.11     │  21.24% │ 202,722,484 │
│ 3.12     │  18.29% │ 174,526,975 │
│ 3.10     │  17.21% │ 164,262,590 │
│ 3.9      │  13.20% │ 125,982,635 │
│ 3.7      │   9.83% │  93,772,574 │
│ 3.13     │   6.81% │  65,006,596 │
│ 3.8      │   6.26% │  59,743,880 │
│ null     │   5.09% │  48,583,823 │
│ 3.6      │   1.76% │  16,806,042 │
│ 2.7      │   0.28% │   2,646,101 │
│ 3.5      │   0.01% │     107,021 │
│ 3.14     │   0.01% │      87,019 │
│ 3.4      │   0.00% │       4,355 │
│ 3.15     │   0.00% │       1,429 │
│ 3.3      │   0.00% │         258 │
│ 2.6      │   0.00% │          21 │
│ 3.2      │   0.00% │           7 │
│ 3.1      │   0.00% │           3 │
│ Total    │         │ 954,253,813 │
└──────────┴─────────┴─────────────┘

Date range: 2025-02-25 - 2025-08-24
```
