### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -9,8 +9,6 @@ jobs:
 
     strategy:
       matrix:
-        Python39:
-          python.version: "3.9"
         Python310:
           python.version: "3.10"
         Python311:
@@ -19,6 +17,8 @@ jobs:
           python.version: "3.12"
         Python313:
           python.version: "3.13"
+        Python314:
+          python.version: "3.14"
 
     steps:
       - task: UsePythonVersion@0.206.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
           - "3.12"
           - "3.11"
           - "3.10"
-          - "3.9"
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,13 @@ keywords = [
 license = "MIT"
 license-files = [ "LICENSE.txt" ]
 authors = [ { name = "Hugo van Kemenade" } ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: End Users/Desktop",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ env_list =
     lint
     mypy
     pins
-    py{py3, 314, 313, 312, 311, 310, 39}
+    py{py3, 314, 313, 312, 311, 310}
 
 [testenv]
 extras =


### PR DESCRIPTION
It's almost end-of-life:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0596/
