### PR TITLE
Use 4.6x faster NumPy and 1.3x faster pandas directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dynamic = [ "version" ]
 dependencies = [
   "platformdirs",
   "prettytable>=3.12",
-  "pytablewriter>=0.63",
   "python-slugify",
   "termcolor>=3.2",
   "tomli; python_version<'3.11'",

--- a/requirements-mypy.txt
+++ b/requirements-mypy.txt
@@ -1,8 +1,8 @@
 freezegun
 mypy==2.1.0
+pandas-stubs
 platformdirs
 prettytable
-pytablewriter
 pytest
 termcolor
 types-python-slugify

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ pandas==3.0.3
 platformdirs==4.10.0
 prettytable==3.18.0
 pyfakefs==6.2.0
-pytablewriter==1.2.1
 pytest==9.0.3
 pytest-cov==7.1.0
 python-slugify==8.0.4

--- a/src/pypistats/__init__.py
+++ b/src/pypistats/__init__.py
@@ -361,10 +361,10 @@ def _tabulate(data: dict | list, format_: str = "markdown", color: str = "yes") 
     headers.append("downloads")
     headers.remove("downloads")
 
-    if format_ in ("html", "markdown", "pretty", "rst", "tsv"):
-        return _prettytable(headers, data, format_, color)
+    if format_ in ("numpy", "pandas"):
+        return _dataframe(headers, data, format_)
     else:
-        return _pytablewriter(headers, data, format_)
+        return _prettytable(headers, data, format_, color)
 
 
 def _prettytable(
@@ -415,63 +415,20 @@ def _prettytable(
         return table.get_string() + "\n"
 
 
-def _pytablewriter(headers, data, format_: str):
-    from pytablewriter import (
-        NumpyTableWriter,
-        PandasDataFrameWriter,
-        RstSimpleTableWriter,
-        String,
-        TsvTableWriter,
-    )
-    from pytablewriter.style import Align, Style, ThousandSeparator
-
-    format_writers = {
-        "numpy": NumpyTableWriter,
-        "pandas": PandasDataFrameWriter,
-        "rst": RstSimpleTableWriter,
-        "tsv": TsvTableWriter,
-    }
-
-    writer = format_writers[format_]()  # type: ignore[abstract]
-    writer.margin = 1
-
+def _dataframe(headers: list[str], data: dict | list, format_: str):
     if isinstance(data, dict):
-        writer.value_matrix = [data]
-    else:  # isinstance(data, list):
-        writer.value_matrix = data
+        data = [data]
 
-    writer.headers = headers
-
-    # Custom alignment and format
-    if headers[0] in ["last_day", "last_month", "last_week"]:
-        # Special case for 'recent'
-        writer.column_styles = len(headers) * [Style(thousand_separator=",")]  # type: ignore[assignment]
-    else:
-        column_styles = []
-        type_hints = []
-
-        for header in headers:
-            align = Align.AUTO
-            thousand_separator = ThousandSeparator.NONE
-            type_hint = None
-            if header == "percent":
-                align = Align.RIGHT
-            elif header == "downloads" and (format_ not in ["numpy", "pandas"]):
-                thousand_separator = ThousandSeparator.COMMA
-            elif header == "category":
-                type_hint = String
-            style = Style(align=align, thousand_separator=thousand_separator)
-            column_styles.append(style)
-            type_hints.append(type_hint)
-
-        writer.column_styles = column_styles  # type: ignore[assignment]
-        writer.type_hints = type_hints  # type: ignore[assignment]
+    rows = [[row.get(header, "") for header in headers] for row in data]
 
     if format_ == "numpy":
-        return writer.tabledata.as_dataframe().values
-    elif format_ == "pandas":
-        return writer.tabledata.as_dataframe()
-    return writer.dumps()
+        import numpy
+
+        return numpy.array(rows, dtype=object)
+
+    import pandas
+
+    return pandas.DataFrame(rows, columns=headers)
 
 
 def _paramify(param_name: str, param_value: float | str | None) -> str:


### PR DESCRIPTION
This means we can remove the `pytablewriter` dependency.

## Timing

### NumPy: 4.64 times faster

```console
❯ hyperfine --warmup 3 \
      --prepare 'git checkout numpy' -n numpy         'python3 -c "import pypistats; pypistats.python_major(\"pillow\", format=\"numpy\")"' \
      --prepare 'git checkout main'  -n pytablewriter 'python3 -c "import pypistats; pypistats.python_major(\"pillow\", format=\"numpy\")"'
Benchmark 1: numpy
  Time (mean ± σ):      66.3 ms ±   1.9 ms    [User: 53.4 ms, System: 11.7 ms]
  Range (min … max):    63.6 ms …  71.6 ms    38 runs

Benchmark 2: pytablewriter
  Time (mean ± σ):     307.9 ms ±   6.8 ms    [User: 253.2 ms, System: 51.6 ms]
  Range (min … max):   297.3 ms … 321.9 ms    10 runs

Summary
  numpy ran
    4.64 ± 0.17 times faster than pytablewriter
```

### pandas: 1.28 times faster

```console
❯ hyperfine --warmup 3 \
      --prepare 'git checkout numpy' -n pandas        'python3 -c "import pypistats; pypistats.python_major(\"pillow\", format=\"pandas\")"' \
      --prepare 'git checkout main'  -n pytablewriter 'python3 -c "import pypistats; pypistats.python_major(\"pillow\", format=\"pandas\")"'
Benchmark 1: pandas
  Time (mean ± σ):     235.5 ms ±   2.4 ms    [User: 193.6 ms, System: 39.5 ms]
  Range (min … max):   231.6 ms … 239.9 ms    11 runs

Benchmark 2: pytablewriter
  Time (mean ± σ):     301.2 ms ±   3.6 ms    [User: 249.3 ms, System: 49.2 ms]
  Range (min … max):   296.0 ms … 307.4 ms    10 runs

Summary
  pandas ran
    1.28 ± 0.02 times faster than pytablewriter
```